### PR TITLE
feat: add Tavily search backend alongside existing providers

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -15,7 +15,7 @@ import (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search the web and return results",
-	Long:  `Search the web using Brave (default), DuckDuckGo, or SearXNG. Add --scrape to fetch and extract full content from results.`,
+	Long:  `Search the web using Brave (default), DuckDuckGo, SearXNG, or Tavily. Add --scrape to fetch and extract full content from results.`,
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  runSearch,
 }
@@ -115,6 +115,11 @@ func newSearcher(cmd *cobra.Command, backend string) (search.Searcher, error) {
 		return search.NewSearXNG(url), nil
 	case "ddg":
 		return search.NewDDG(), nil
+	case "tavily":
+		if cfg.TavilyAPIKey == "" {
+			return nil, fmt.Errorf("tavily: API key not set (get one at https://app.tavily.com then: ketch config set tavily_api_key <key>)")
+		}
+		return search.NewTavily(cfg.TavilyAPIKey), nil
 	default:
 		return nil, fmt.Errorf("unknown backend: %s", backend)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,8 @@ import (
 type Config struct {
 	Backend     string `json:"backend"`
 	SearxngURL  string `json:"searxng_url"`
-	BraveAPIKey string `json:"brave_api_key,omitempty"`
+	BraveAPIKey  string `json:"brave_api_key,omitempty"`
+	TavilyAPIKey string `json:"tavily_api_key,omitempty"`
 	Limit       int    `json:"limit"`
 	CacheTTL    string `json:"cache_ttl"`
 	Browser     string `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
@@ -28,7 +29,7 @@ func Defaults() Config {
 
 // AvailableBackends returns the list of known search backends.
 func AvailableBackends() []string {
-	return []string{"brave", "ddg", "searxng"}
+	return []string{"brave", "ddg", "searxng", "tavily"}
 }
 
 // Path returns the config file path (~/.config/ketch/config.json).

--- a/internal/search/tavily.go
+++ b/internal/search/tavily.go
@@ -1,0 +1,91 @@
+package search
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Tavily searches via the Tavily Search API.
+type Tavily struct {
+	apiKey string
+	client *http.Client
+}
+
+// NewTavily creates a new Tavily search backend.
+func NewTavily(apiKey string) *Tavily {
+	return &Tavily{
+		apiKey: apiKey,
+		client: &http.Client{},
+	}
+}
+
+type tavilyRequest struct {
+	APIKey     string `json:"api_key"`
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results"`
+}
+
+type tavilyResponse struct {
+	Results []tavilyResult `json:"results"`
+}
+
+type tavilyResult struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Content string `json:"content"`
+}
+
+// Search queries Tavily and returns up to limit results.
+func (t *Tavily) Search(query string, limit int) ([]Result, error) {
+	body, err := json.Marshal(tavilyRequest{
+		APIKey:     t.apiKey,
+		Query:      query,
+		MaxResults: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", "https://api.tavily.com/search", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tavily request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("tavily: invalid API key (set via: ketch config set tavily_api_key <key>)")
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("tavily: rate limited")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tavily returned status %d", resp.StatusCode)
+	}
+
+	var tr tavilyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("failed to decode tavily response: %w", err)
+	}
+
+	results := make([]Result, 0, limit)
+	for _, r := range tr.Results {
+		if len(results) >= limit {
+			break
+		}
+		results = append(results, Result{
+			Title:       r.Title,
+			URL:         r.URL,
+			Description: r.Content,
+		})
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
## Summary

- Added Tavily as a fourth search backend (`--backend tavily`), keeping all existing backends (brave, ddg, searxng) intact
- New `internal/search/tavily.go` implements the `Searcher` interface using Tavily's REST API (POST https://api.tavily.com/search)
- No new Go module dependencies — uses stdlib `net/http` + `encoding/json`, matching the pattern of `brave.go` and `searxng.go`

## Files changed

- `internal/search/tavily.go` — **new**: Tavily backend implementing `Search(query, limit)` via POST /search
- `internal/config/config.go` — added `TavilyAPIKey` field to `Config` struct; added `"tavily"` to `AvailableBackends()`
- `cmd/search.go` — added `case "tavily"` in `newSearcher()` with API key validation; updated command long description

## Env var changes

- `TAVILY_API_KEY` — configure via `ketch config set tavily_api_key <key>` (stored in `~/.config/ketch/config.json`)

## Notes for reviewers

- This is an additive change — no existing backends are modified
- Error handling follows the same pattern as the Brave backend (401 → invalid key, 429 → rate limited)
- Go toolchain was not available in CI environment to verify compilation; code follows identical patterns to existing backends


### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily backend is a clean, additive implementation that correctly follows the patterns established by the existing Brave backend. All three expected files are modified with no unintended changes, no new dependencies are needed, and the Searcher interface is satisfied. Two minor issues noted but neither blocks approval.
