### PR TITLE
feat: add ketch code and ketch docs commands (Sourcegraph + Context7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ cmd/
   scrape.go                  Scrape command: URLs → markdown, concurrent batch
   crawl.go                   Crawl command: BFS/sitemap crawl with streaming output
   crawl_bg.go                Background crawl: status, stop subcommands, worker mode
+  code.go                    Code search command: query → snippet results, --lang qualifier
+  docs.go                    Docs search command: query → docs/snippet results, --library, --resolve
   config.go                  Config command: discovery, init, set, path
   cache.go                   Cache command: stats, clear
   browser.go                 Browser command: install, status
@@ -23,6 +25,13 @@ internal/
     brave.go                 Brave Search API backend (default)
     ddg.go                   DuckDuckGo HTML backend
     searxng.go               SearXNG JSON API backend
+  code/
+    code.go                  code.Searcher interface + Result type
+    sourcegraph.go           Sourcegraph SSE streaming backend (no auth required)
+  docs/
+    docs.go                  docs.Searcher interface + Result type
+    context7.go              Context7 two-step resolve+fetch backend (API key required)
+    fts5.go                  Local FTS5 SQLite backend stub (planned)
   scrape/
     scrape.go                HTTP fetch chain + Page type, JS detection fallback
     browser_iface.go         BrowserConn interface + ResolveBrowserBin
@@ -47,6 +56,7 @@ internal/
 - **Interface-driven backends**: `Searcher` for search engines, `Store` for cache backends, `BrowserConn` for browser rendering.
 - **Concurrent by default**: multiple URLs scraped in parallel via goroutines.
 - **Operator configures, agent consumes**: config sets defaults (backend, browser, cache TTL) so agents don't need to know infrastructure.
+- **Three search surfaces**: `ketch search` finds web pages, `ketch code` greps real OSS code, `ketch docs` fetches library documentation. Each has its own backend interface and Result type — they never share backends.
 
 ## Quality Standards
 
@@ -70,6 +80,11 @@ ketch crawl status [id]                     # check crawl progress
 ketch crawl stop <id>                       # stop a background crawl
 ketch browser status                        # check browser config
 ketch browser install                       # download Chromium
+ketch code "query"                          # code search (sourcegraph)
+ketch code "query" --lang go               # with language filter
+ketch docs "query"                          # docs search (context7)
+ketch docs "query" --library /org/repo     # skip resolve, fetch directly
+ketch docs --resolve "library name"        # resolve library name → Context7 IDs
 ketch config                                # show effective config + backends
 ketch cache                                 # show cache stats
 ```
@@ -91,3 +106,8 @@ ketch cache                                 # show cache stats
 | --background | crawl | false | Run in background |
 | --allow | crawl | — | Path substring filters |
 | --deny | crawl | — | Regex deny patterns |
+| --backend, -b | code, docs | cfg value | Code/docs backend |
+| --lang | code | — | Language qualifier (appended to query) |
+| --library | docs | — | Context7 library ID, skips resolve |
+| --tokens | docs | 4000 | Context7 token budget |
+| --resolve | docs | false | Resolve library name instead of searching |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,39 @@ Default output uses YAML frontmatter + markdown (cymbal style):
 - `ketch search` — frontmatter (query, backend, result_count) + result list
 - `--json` flag available on all commands for structured JSON output
 
-### Search Backends
+### Search Backends (ketch search)
 
 | Backend | Setup | Notes |
 |---------|-------|-------|
 | `brave` (default) | Free API key from brave.com/search/api | Stable JSON API |
 | `ddg` | Zero config | Rate-limited by DDG currently |
 | `searxng` | Self-hosted instance | Most reliable for heavy use |
+
+### Code Backends (ketch code)
+
+| Backend | Setup | Notes |
+|---------|-------|-------|
+| `sourcegraph` (default) | Zero config | Grep-style, ~1M OSS repos, exact line matches, SSE stream |
+
+```bash
+ketch code "http.NewRequestWithContext" --lang go
+ketch code "rate limit middleware" --lang go --limit 10
+ketch config set sourcegraph_url https://sourcegraph.com  # optional, for self-hosted
+```
+
+### Docs Backends (ketch docs)
+
+| Backend | Setup | Notes |
+|---------|-------|-------|
+| `context7` (default) | Free key: `ketch config set context7_api_key <key>` | Curated snippets + prose, version-aware |
+| `local` | `ketch docs index <source>` | FTS5 SQLite, offline/private docs (planned) |
+
+```bash
+ketch config set context7_api_key ctx7sk_...
+ketch docs "how to render with word wrap" --library /charmbracelet/glamour
+ketch docs "middleware authentication"          # context7 auto-resolves library
+ketch docs --resolve "glamour"                 # list matching library IDs
+```
 
 ### Browser Rendering
 
@@ -104,5 +130,6 @@ GoReleaser + GitHub Actions (`.goreleaser.yaml`, `.github/workflows/release.yml`
 
 ### What's Next
 
-1. Unit tests for extract, search, and cache packages
+1. Unit tests for extract, search, code, docs, and cache packages
 2. `--raw` flag implementation in scrape command
+3. Local FTS5 SQLite docs backend (`ketch docs index`) for offline/private docs

--- a/README.md
+++ b/README.md
@@ -144,13 +144,45 @@ ketch config
 }
 ```
 
-### Search backends
+### Search Backends (ketch search)
 
-| Backend | Description | Setup |
-|---------|-------------|-------|
-| `brave` | Brave Search JSON API (default) | Free API key from [brave.com/search/api](https://brave.com/search/api/) |
-| `ddg` | DuckDuckGo HTML scraping (zero config) | None |
-| `searxng` | SearXNG JSON API (self-hosted, most reliable) | Run a [SearXNG](https://docs.searxng.org/) instance |
+| Backend | Setup | Notes |
+|---------|-------|-------|
+| `brave` (default) | Free API key from brave.com/search/api | Stable JSON API |
+| `ddg` | Zero config | Rate-limited by DDG currently |
+| `searxng` | Self-hosted instance | Most reliable for heavy use |
+
+### Code Backends (ketch code)
+
+| Backend | Setup | Notes |
+|---------|-------|-------|
+| `sourcegraph` (default) | Zero config | Grep-style, ~1M OSS repos, exact line matches, SSE stream |
+
+```bash
+ketch code "http.NewRequestWithContext" --lang go
+ketch code "rate limit middleware" --lang go --limit 10
+ketch config set sourcegraph_url https://sourcegraph.com  # optional, for self-hosted
+```
+
+### Docs Backends (ketch docs)
+
+| Backend | Setup | Notes |
+|---------|-------|-------|
+| `context7` (default) | Free key: `ketch config set context7_api_key <key>` | Curated snippets + prose, version-aware |
+| `local` | `ketch docs index <source>` | FTS5 SQLite, offline/private docs (planned) |
+
+```bash
+ketch config set context7_api_key ctx7sk_...
+ketch docs "how to render with word wrap" --library /charmbracelet/glamour
+ketch docs "middleware authentication"          # context7 auto-resolves library
+ketch docs --resolve "glamour"                 # list matching library IDs
+```
+
+### What's Next
+
+1. Unit tests for extract, search, code, docs, and cache packages
+2. `--raw` flag implementation in scrape command
+3. Local FTS5 SQLite docs backend (`ketch docs index`) for offline/private docs
 
 ## Agent integration
 

--- a/cmd/code.go
+++ b/cmd/code.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/1broseidon/ketch/internal/code"
+	"github.com/1broseidon/ketch/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var codeCmd = &cobra.Command{
+	Use:   "code <query>",
+	Short: "Search code across open-source repositories",
+	Long:  `Search code using Sourcegraph. Supports language filtering and Sourcegraph query qualifiers.`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runCode,
+}
+
+func init() {
+	rootCmd.AddCommand(codeCmd)
+	codeCmd.Flags().StringP("backend", "b", cfg.CodeBackend, "code search backend: "+strings.Join(config.AvailableCodeBackends(), ", "))
+	codeCmd.Flags().String("lang", "", "language filter (appended to query)")
+	codeCmd.Flags().IntP("limit", "l", cfg.Limit, "max number of results")
+}
+
+func runCode(cmd *cobra.Command, args []string) error {
+	query := args[0]
+	backend, _ := cmd.Flags().GetString("backend")
+	lang, _ := cmd.Flags().GetString("lang")
+	limit, _ := cmd.Flags().GetInt("limit")
+	asJSON, _ := cmd.Root().PersistentFlags().GetBool("json")
+
+	if lang != "" {
+		query += " lang:" + lang
+	}
+
+	searcher, err := newCodeSearcher(backend)
+	if err != nil {
+		return err
+	}
+
+	results, err := searcher.Search(query, limit)
+	if err != nil {
+		return fmt.Errorf("code search failed: %w", err)
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(results)
+	}
+
+	fmt.Println("---")
+	fmt.Printf("query: %s\n", query)
+	fmt.Printf("backend: %s\n", backend)
+	fmt.Printf("result_count: %d\n", len(results))
+	fmt.Println("---")
+	for _, r := range results {
+		fmt.Printf("%s  %s  (line %d)\n", r.Repo, r.Path, r.Line)
+		fmt.Printf("  %s\n", r.Snippet)
+		fmt.Println()
+	}
+	return nil
+}
+
+func newCodeSearcher(backend string) (code.Searcher, error) {
+	switch backend {
+	case "sourcegraph":
+		return code.NewSourcegraph(cfg.SourcegraphURL), nil
+	default:
+		return nil, fmt.Errorf("unknown code backend: %s", backend)
+	}
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,13 +13,18 @@ import (
 
 // configInfo is the discovery payload returned by `ketch config`.
 type configInfo struct {
-	ConfigPath        string   `json:"config_path"`
-	Backend           string   `json:"backend"`
-	SearxngURL        string   `json:"searxng_url"`
-	Limit             int      `json:"limit"`
-	CacheTTL          string   `json:"cache_ttl"`
-	Browser           string   `json:"browser,omitempty"`
-	AvailableBackends []string `json:"available_backends"`
+	ConfigPath            string   `json:"config_path"`
+	Backend               string   `json:"backend"`
+	SearxngURL            string   `json:"searxng_url"`
+	Limit                 int      `json:"limit"`
+	CacheTTL              string   `json:"cache_ttl"`
+	Browser               string   `json:"browser,omitempty"`
+	CodeBackend           string   `json:"code_backend"`
+	DocsBackend           string   `json:"docs_backend"`
+	SourcegraphURL        string   `json:"sourcegraph_url"`
+	AvailableBackends     []string `json:"available_backends"`
+	AvailableCodeBackends []string `json:"available_code_backends"`
+	AvailableDocBackends  []string `json:"available_doc_backends"`
 }
 
 var configCmd = &cobra.Command{
@@ -60,13 +65,18 @@ func runConfigShow(_ *cobra.Command, _ []string) error {
 	path, _ := config.Path()
 
 	info := configInfo{
-		ConfigPath:        path,
-		Backend:           c.Backend,
-		SearxngURL:        c.SearxngURL,
-		Limit:             c.Limit,
-		CacheTTL:          c.CacheTTL,
-		Browser:           c.Browser,
-		AvailableBackends: config.AvailableBackends(),
+		ConfigPath:            path,
+		Backend:               c.Backend,
+		SearxngURL:            c.SearxngURL,
+		Limit:                 c.Limit,
+		CacheTTL:              c.CacheTTL,
+		Browser:               c.Browser,
+		CodeBackend:           c.CodeBackend,
+		DocsBackend:           c.DocsBackend,
+		SourcegraphURL:        c.SourcegraphURL,
+		AvailableBackends:     config.AvailableBackends(),
+		AvailableCodeBackends: config.AvailableCodeBackends(),
+		AvailableDocBackends:  config.AvailableDocBackends(),
 	}
 
 	enc := json.NewEncoder(os.Stdout)
@@ -116,8 +126,16 @@ func runConfigSet(_ *cobra.Command, args []string) error {
 		c.CacheTTL = value
 	case "browser":
 		c.Browser = value
+	case "code_backend":
+		c.CodeBackend = value
+	case "docs_backend":
+		c.DocsBackend = value
+	case "context7_api_key":
+		c.Context7APIKey = value
+	case "sourcegraph_url":
+		c.SourcegraphURL = value
 	default:
-		return fmt.Errorf("unknown key: %s (valid: backend, searxng_url, brave_api_key, limit, cache_ttl, browser)", key)
+		return fmt.Errorf("unknown key: %s (valid: backend, searxng_url, brave_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url)", key)
 	}
 
 	if err := config.Save(c); err != nil {

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/1broseidon/ketch/internal/config"
+	"github.com/1broseidon/ketch/internal/docs"
+	"github.com/spf13/cobra"
+)
+
+var docsCmd = &cobra.Command{
+	Use:   "docs <query>",
+	Short: "Search library documentation",
+	Long:  `Search library documentation using Context7 or a local FTS5 backend. Supports direct library ID lookup and library name resolution.`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runDocs,
+}
+
+func init() {
+	rootCmd.AddCommand(docsCmd)
+	docsCmd.Flags().StringP("backend", "b", cfg.DocsBackend, "docs backend: "+strings.Join(config.AvailableDocBackends(), ", "))
+	docsCmd.Flags().String("library", "", "Context7 library ID (skip resolve step)")
+	docsCmd.Flags().Int("tokens", 4000, "Context7 token budget")
+	docsCmd.Flags().IntP("limit", "l", cfg.Limit, "max number of results")
+	docsCmd.Flags().Bool("resolve", false, "resolve library name instead of searching")
+}
+
+func runDocs(cmd *cobra.Command, args []string) error {
+	query := strings.Join(args, " ")
+	backend, _ := cmd.Flags().GetString("backend")
+	library, _ := cmd.Flags().GetString("library")
+	tokens, _ := cmd.Flags().GetInt("tokens")
+	limit, _ := cmd.Flags().GetInt("limit")
+	resolve, _ := cmd.Flags().GetBool("resolve")
+	asJSON, _ := cmd.Root().PersistentFlags().GetBool("json")
+
+	if resolve {
+		return runDocsResolve(query, asJSON)
+	}
+
+	if library != "" && backend == "context7" {
+		return runDocsWithLibrary(query, library, tokens, asJSON)
+	}
+
+	searcher, err := newDocSearcher(backend)
+	if err != nil {
+		return err
+	}
+
+	results, err := searcher.Search(query, limit)
+	if err != nil {
+		return fmt.Errorf("docs search failed: %w", err)
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(results)
+	}
+
+	printDocsResults(query, backend, "", results)
+	return nil
+}
+
+func runDocsResolve(query string, asJSON bool) error {
+	if cfg.Context7APIKey == "" {
+		return fmt.Errorf("context7: API key not set (get one then: ketch config set context7_api_key <key>)")
+	}
+
+	c7 := docs.NewContext7(cfg.Context7APIKey)
+	matches, err := c7.ResolveLibrary(query)
+	if err != nil {
+		return fmt.Errorf("resolve failed: %w", err)
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(matches)
+	}
+
+	for _, m := range matches {
+		fmt.Printf("%s  %s  (snippets: %d)\n", m.ID, m.Name, m.CodeSnippets)
+	}
+	return nil
+}
+
+func runDocsWithLibrary(query, library string, tokens int, asJSON bool) error {
+	if cfg.Context7APIKey == "" {
+		return fmt.Errorf("context7: API key not set (get one then: ketch config set context7_api_key <key>)")
+	}
+
+	c7 := docs.NewContext7(cfg.Context7APIKey)
+	results, err := c7.GetDocs(library, query, tokens)
+	if err != nil {
+		return fmt.Errorf("docs fetch failed: %w", err)
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(results)
+	}
+
+	printDocsResults(query, "context7", library, results)
+	return nil
+}
+
+func printDocsResults(query, backend, library string, results []docs.Result) {
+	fmt.Println("---")
+	fmt.Printf("query: %s\n", query)
+	fmt.Printf("backend: %s\n", backend)
+	if library != "" {
+		fmt.Printf("library: %s\n", library)
+	} else if len(results) > 0 && results[0].Library != "" {
+		fmt.Printf("library: %s\n", results[0].Library)
+	}
+	fmt.Printf("result_count: %d\n", len(results))
+	fmt.Println("---")
+	for _, r := range results {
+		label := r.Title
+		if r.Breadcrumb != "" {
+			label = r.Breadcrumb
+		}
+		fmt.Printf("[%s]\n", label)
+		fmt.Printf("  %s\n", r.Snippet)
+		fmt.Printf("  source: %s\n", r.URL)
+		fmt.Println()
+	}
+}
+
+func newDocSearcher(backend string) (docs.Searcher, error) {
+	switch backend {
+	case "context7":
+		if cfg.Context7APIKey == "" {
+			return nil, fmt.Errorf("context7: API key not set (get one then: ketch config set context7_api_key <key>)")
+		}
+		return docs.NewContext7(cfg.Context7APIKey), nil
+	case "local":
+		return docs.NewFTS5Local(), nil
+	default:
+		return nil, fmt.Errorf("unknown docs backend: %s", backend)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cfg config.Config
+var cfg = config.Load()
 
 var rootCmd = &cobra.Command{
 	Use:   "ketch",
@@ -21,7 +21,6 @@ func Execute() error {
 }
 
 func init() {
-	cfg = config.Load()
 	rootCmd.PersistentFlags().Bool("json", false, "output as JSON")
 	rootCmd.PersistentFlags().StringP("backend", "b", cfg.Backend,
 		fmt.Sprintf("search backend: %s", strings.Join(config.AvailableBackends(), ", ")))

--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -1,0 +1,17 @@
+package code
+
+// Result is a single code search result.
+type Result struct {
+	Repo     string `json:"repo"`
+	Path     string `json:"path"`
+	Line     int    `json:"line,omitempty"`
+	Snippet  string `json:"snippet"`
+	Language string `json:"language,omitempty"`
+	URL      string `json:"url"`
+	Source   string `json:"source"` // "sourcegraph"
+}
+
+// Searcher is the interface for code search backends.
+type Searcher interface {
+	Search(query string, limit int) ([]Result, error)
+}

--- a/internal/code/sourcegraph.go
+++ b/internal/code/sourcegraph.go
@@ -1,0 +1,115 @@
+package code
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Sourcegraph searches code via the Sourcegraph streaming search API.
+type Sourcegraph struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewSourcegraph creates a new Sourcegraph code search backend.
+func NewSourcegraph(baseURL string) *Sourcegraph {
+	return &Sourcegraph{
+		baseURL: baseURL,
+		client:  &http.Client{},
+	}
+}
+
+type sseContentMatch struct {
+	Type        string         `json:"type"`
+	Repository  string         `json:"repository"`
+	Path        string         `json:"path"`
+	Language    string         `json:"language"`
+	RepoStars   int            `json:"repoStars"`
+	LineMatches []sseLineMatch `json:"lineMatches"`
+}
+
+type sseLineMatch struct {
+	Line       string `json:"line"`
+	LineNumber int    `json:"lineNumber"`
+}
+
+// Search queries Sourcegraph and returns up to limit code results.
+func (s *Sourcegraph) Search(query string, limit int) ([]Result, error) {
+	u := fmt.Sprintf("%s/.api/search/stream?q=%s&display=%d",
+		s.baseURL, url.QueryEscape(query), limit)
+
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sourcegraph request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("sourcegraph returned status %d", resp.StatusCode)
+	}
+
+	return s.parseSSE(resp, limit)
+}
+
+func (s *Sourcegraph) parseSSE(resp *http.Response, limit int) ([]Result, error) {
+	var results []Result
+	var eventType string
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "event:") {
+			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			continue
+		}
+
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		if eventType != "matches" {
+			continue
+		}
+
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		var matches []sseContentMatch
+		if err := json.Unmarshal([]byte(data), &matches); err != nil {
+			continue
+		}
+
+		for _, m := range matches {
+			if m.Type != "content" || len(m.LineMatches) == 0 {
+				continue
+			}
+			if len(results) >= limit {
+				return results, nil
+			}
+			lm := m.LineMatches[0]
+			results = append(results, Result{
+				Repo:     m.Repository,
+				Path:     m.Path,
+				Line:     lm.LineNumber,
+				Snippet:  lm.Line,
+				Language: m.Language,
+				URL:      fmt.Sprintf("%s/%s/-/blob/%s#L%d", s.baseURL, m.Repository, m.Path, lm.LineNumber),
+				Source:   "sourcegraph",
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return results, fmt.Errorf("sourcegraph stream error: %w", err)
+	}
+
+	return results, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,21 +8,28 @@ import (
 
 // Config holds user-configurable defaults for ketch.
 type Config struct {
-	Backend     string `json:"backend"`
-	SearxngURL  string `json:"searxng_url"`
-	BraveAPIKey string `json:"brave_api_key,omitempty"`
-	Limit       int    `json:"limit"`
-	CacheTTL    string `json:"cache_ttl"`
-	Browser     string `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
+	Backend        string `json:"backend"`
+	SearxngURL     string `json:"searxng_url"`
+	BraveAPIKey    string `json:"brave_api_key,omitempty"`
+	Limit          int    `json:"limit"`
+	CacheTTL       string `json:"cache_ttl"`
+	Browser        string `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
+	CodeBackend    string `json:"code_backend,omitempty"`
+	DocsBackend    string `json:"docs_backend,omitempty"`
+	Context7APIKey string `json:"context7_api_key,omitempty"`
+	SourcegraphURL string `json:"sourcegraph_url,omitempty"`
 }
 
 // Defaults returns the built-in default configuration.
 func Defaults() Config {
 	return Config{
-		Backend:    "brave",
-		SearxngURL: "http://localhost:8081",
-		Limit:      5,
-		CacheTTL:   "72h",
+		Backend:        "brave",
+		SearxngURL:     "http://localhost:8081",
+		Limit:          5,
+		CacheTTL:       "72h",
+		CodeBackend:    "sourcegraph",
+		DocsBackend:    "context7",
+		SourcegraphURL: "https://sourcegraph.com",
 	}
 }
 
@@ -30,6 +37,12 @@ func Defaults() Config {
 func AvailableBackends() []string {
 	return []string{"brave", "ddg", "searxng"}
 }
+
+// AvailableCodeBackends returns the list of known code search backends.
+func AvailableCodeBackends() []string { return []string{"sourcegraph"} }
+
+// AvailableDocBackends returns the list of known docs backends.
+func AvailableDocBackends() []string { return []string{"context7", "local"} }
 
 // Path returns the config file path (~/.config/ketch/config.json).
 func Path() (string, error) {

--- a/internal/docs/context7.go
+++ b/internal/docs/context7.go
@@ -1,0 +1,159 @@
+package docs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Context7 searches library documentation via the Context7 API.
+type Context7 struct {
+	apiKey string
+	client *http.Client
+}
+
+// NewContext7 creates a new Context7 docs backend.
+func NewContext7(apiKey string) *Context7 {
+	return &Context7{
+		apiKey: apiKey,
+		client: &http.Client{},
+	}
+}
+
+// LibraryMatch is a resolved library from Context7's search endpoint.
+type LibraryMatch struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Description  string   `json:"description"`
+	CodeSnippets int      `json:"codeSnippets"`
+	Trust        string   `json:"trust"`
+	Versions     []string `json:"versions"`
+}
+
+type context7DocsResponse struct {
+	CodeSnippets []context7CodeSnippet `json:"codeSnippets"`
+	InfoSnippets []context7InfoSnippet `json:"infoSnippets"`
+}
+
+type context7CodeSnippet struct {
+	CodeTitle       string              `json:"codeTitle"`
+	CodeDescription string              `json:"codeDescription"`
+	CodeLanguage    string              `json:"codeLanguage"`
+	CodeID          string              `json:"codeId"`
+	CodeList        []context7CodeEntry `json:"codeList"`
+}
+
+type context7CodeEntry struct {
+	Language string `json:"language"`
+	Code     string `json:"code"`
+}
+
+type context7InfoSnippet struct {
+	PageID     string `json:"pageId"`
+	Breadcrumb string `json:"breadcrumb"`
+	Content    string `json:"content"`
+}
+
+// Search resolves a library from the query and fetches documentation.
+func (c *Context7) Search(query string, limit int) ([]Result, error) {
+	libs, err := c.ResolveLibrary(query)
+	if err != nil {
+		return nil, fmt.Errorf("context7 resolve failed: %w", err)
+	}
+	if len(libs) == 0 {
+		return nil, fmt.Errorf("context7: no library found for %q", query)
+	}
+
+	return c.GetDocs(libs[0].ID, query, 4000)
+}
+
+// ResolveLibrary searches Context7 for libraries matching the given name.
+func (c *Context7) ResolveLibrary(name string) ([]LibraryMatch, error) {
+	u := fmt.Sprintf("https://context7.com/api/v1/search?q=%s", url.QueryEscape(name))
+
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("context7 resolve request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("context7: invalid API key (set via: ketch config set context7_api_key <key>)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("context7 resolve returned status %d", resp.StatusCode)
+	}
+
+	var matches []LibraryMatch
+	if err := json.NewDecoder(resp.Body).Decode(&matches); err != nil {
+		return nil, fmt.Errorf("failed to decode context7 resolve response: %w", err)
+	}
+
+	return matches, nil
+}
+
+// GetDocs fetches documentation snippets for a resolved library ID.
+func (c *Context7) GetDocs(libraryID, query string, tokens int) ([]Result, error) {
+	u := fmt.Sprintf("https://context7.com/api/v2/context?libraryId=%s&query=%s&type=json&tokens=%d",
+		url.QueryEscape(libraryID), url.QueryEscape(query), tokens)
+
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("context7 docs request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("context7: invalid API key (set via: ketch config set context7_api_key <key>)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("context7 docs returned status %d", resp.StatusCode)
+	}
+
+	var dr context7DocsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return nil, fmt.Errorf("failed to decode context7 docs response: %w", err)
+	}
+
+	var results []Result
+
+	for _, cs := range dr.CodeSnippets {
+		snippet := ""
+		if len(cs.CodeList) > 0 {
+			snippet = cs.CodeList[0].Code
+		}
+		results = append(results, Result{
+			Library: libraryID,
+			Title:   cs.CodeTitle,
+			Snippet: snippet,
+			URL:     cs.CodeID,
+			Source:  "context7",
+		})
+	}
+
+	for _, is := range dr.InfoSnippets {
+		results = append(results, Result{
+			Library:    libraryID,
+			Title:      is.Breadcrumb,
+			Breadcrumb: is.Breadcrumb,
+			Snippet:    is.Content,
+			URL:        is.PageID,
+			Source:     "context7",
+		})
+	}
+
+	return results, nil
+}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1,0 +1,17 @@
+package docs
+
+// Result is a single docs search result.
+type Result struct {
+	Library    string `json:"library"`
+	Version    string `json:"version,omitempty"`
+	Title      string `json:"title"`
+	Breadcrumb string `json:"breadcrumb,omitempty"`
+	Snippet    string `json:"snippet"`
+	URL        string `json:"url"`
+	Source     string `json:"source"` // "context7" | "local"
+}
+
+// Searcher is the interface for docs backends.
+type Searcher interface {
+	Search(query string, limit int) ([]Result, error)
+}

--- a/internal/docs/fts5.go
+++ b/internal/docs/fts5.go
@@ -1,0 +1,14 @@
+package docs
+
+import "fmt"
+
+// FTS5Local is a planned local SQLite FTS5 docs backend. Not yet implemented.
+type FTS5Local struct{}
+
+// NewFTS5Local creates a new FTS5Local backend stub.
+func NewFTS5Local() *FTS5Local { return &FTS5Local{} }
+
+// Search returns an error because the local FTS5 backend is not yet implemented.
+func (f *FTS5Local) Search(_ string, _ int) ([]Result, error) {
+	return nil, fmt.Errorf("local fts5 backend not yet implemented")
+}


### PR DESCRIPTION
## Summary

- **`ketch code`**: New code search command using Sourcegraph streaming SSE API. Supports `--lang` filter (appends to query), `--limit`, `--backend`, and `--json`. Zero config — no auth required.
- **`ketch docs`**: New docs search command using Context7 two-step resolve+fetch API. Supports `--library` (skip resolve), `--resolve` (list matching library IDs), `--tokens`, `--limit`, `--backend`, and `--json`. Requires API key.
- **`internal/code`**: `code.Searcher` interface + `Sourcegraph` backend (SSE stream parsing)
- **`internal/docs`**: `docs.Searcher` interface + `Context7` backend (resolve + getdocs) + `FTS5Local` stub
- **Config**: New keys `code_backend`, `docs_backend`, `context7_api_key`, `sourcegraph_url` with defaults
- **Docs**: Updated CLAUDE.md, AGENTS.md, and README.md with new backends, commands, flags, and design principles

## New config keys

```bash
ketch config set context7_api_key <key>     # required for ketch docs
ketch config set sourcegraph_url <url>      # optional, for self-hosted Sourcegraph
ketch config set code_backend sourcegraph   # default
ketch config set docs_backend context7      # default
```

## Example usage

```bash
# Code search
ketch code "http.NewRequestWithContext" --lang go
ketch code "rate limit middleware" --lang go --limit 10

# Docs search
ketch docs "how to render with word wrap" --library /charmbracelet/glamour
ketch docs "middleware authentication"
ketch docs --resolve "glamour"
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] No new external dependencies
- [x] CGO_ENABLED=0 — pure Go

🤖 Generated with [Claude Code](https://claude.com/claude-code)