### PR TITLE
feat: --select CSS extraction + llms.txt auto-detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ internal/
     fts5.go                  Local FTS5 SQLite backend stub (planned)
   scrape/
     scrape.go                HTTP fetch chain + Page type, JS detection fallback
+                             Scraper.Fetch() is exported — returns raw HTML before extraction pipeline
     browser_iface.go         BrowserConn interface + ResolveBrowserBin
     browser.go               Rod-based headless Chrome fetch
   extract/
@@ -115,3 +116,5 @@ ketch cache                                 # show cache stats
 | --max-chars N | scrape, search --scrape | 0 (off) | Truncate markdown output to N chars, appends `[truncated]` |
 | --trim | scrape, search --scrape | false | Strip markdown formatting syntax, keep content text only |
 | --minimal | search, code, docs | false | One result per line, tab-separated, no frontmatter |
+| --select \<css\> | scrape | — | Extract only elements matching CSS selector (skips readability) |
+| --no-llms-txt | scrape | false | Disable automatic /llms.txt detection for bare domains |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ Default output uses YAML frontmatter + markdown (cymbal style):
 | `--max-chars N` | scrape, search --scrape | 0 (off) | Truncate markdown output to N chars, appends `[truncated]` |
 | `--trim` | scrape, search --scrape | false | Strip markdown formatting syntax, keep content text only (~30-40% token reduction) |
 | `--minimal` | search, code, docs | false | One result per line, tab-separated url/title/snippet, no frontmatter |
+| `--select <css>` | scrape | — | Extract only elements matching CSS selector (skips readability) |
+| `--no-llms-txt` | scrape | false | Disable automatic /llms.txt detection for bare domains |
 
 ### Search Backends (ketch search)
 

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -15,7 +15,6 @@ import (
 	"github.com/1broseidon/ketch/internal/cache"
 	"github.com/1broseidon/ketch/internal/extract"
 	"github.com/1broseidon/ketch/internal/scrape"
-	"github.com/PuerkitoBio/goquery"
 	"github.com/spf13/cobra"
 )
 
@@ -176,6 +175,10 @@ func scrapeWithSelector(s *scrape.Scraper, rawURL string, asJSON bool, trim bool
 		return fmt.Errorf("fetch failed: %w", err)
 	}
 
+	// Apply browser fallback for JS-rendered pages before running the selector,
+	// otherwise the selector matches against the empty shell, not the real content.
+	html = s.MaybeBrowserFetch(rawURL, html)
+
 	markdown, err := extract.ExtractSelector(html, selector)
 	if err != nil {
 		return fmt.Errorf("selector extraction failed: %w", err)
@@ -184,7 +187,7 @@ func scrapeWithSelector(s *scrape.Scraper, rawURL string, asJSON bool, trim bool
 		return fmt.Errorf("no elements matched selector %q", selector)
 	}
 
-	title := extractTitleFromHTML(html)
+	title := extract.Title(html)
 	page := &scrape.Page{URL: rawURL, Title: title, Markdown: markdown}
 	page.Markdown = postProcess(page.Markdown, trim, maxChars)
 
@@ -193,15 +196,6 @@ func scrapeWithSelector(s *scrape.Scraper, rawURL string, asJSON bool, trim bool
 	}
 	printPage(page)
 	return nil
-}
-
-// extractTitleFromHTML pulls the <title> tag from raw HTML.
-func extractTitleFromHTML(html string) string {
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(doc.Find("title").First().Text())
 }
 
 // fetchLLMSTxt attempts to fetch /llms.txt from the given base URL.

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -12,6 +15,7 @@ import (
 	"github.com/1broseidon/ketch/internal/cache"
 	"github.com/1broseidon/ketch/internal/extract"
 	"github.com/1broseidon/ketch/internal/scrape"
+	"github.com/PuerkitoBio/goquery"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +33,8 @@ func init() {
 	scrapeCmd.Flags().Bool("no-cache", false, "bypass the page cache")
 	scrapeCmd.Flags().Int("max-chars", 0, "truncate markdown output to N chars (0 = disabled)")
 	scrapeCmd.Flags().Bool("trim", false, "strip markdown formatting, keep content text only")
+	scrapeCmd.Flags().String("select", "", "CSS selector to extract specific elements (skips readability)")
+	scrapeCmd.Flags().Bool("no-llms-txt", false, "disable automatic /llms.txt detection for bare domains")
 }
 
 func runScrape(cmd *cobra.Command, args []string) error {
@@ -36,6 +42,8 @@ func runScrape(cmd *cobra.Command, args []string) error {
 	noCache, _ := cmd.Flags().GetBool("no-cache")
 	maxChars, _ := cmd.Flags().GetInt("max-chars")
 	trim, _ := cmd.Flags().GetBool("trim")
+	selector, _ := cmd.Flags().GetString("select")
+	noLLMSTxt, _ := cmd.Flags().GetBool("no-llms-txt")
 
 	var scraper *scrape.Scraper
 	if cfg.Browser != "" {
@@ -49,7 +57,7 @@ func runScrape(cmd *cobra.Command, args []string) error {
 	defer pc.Close()
 
 	if len(args) == 1 {
-		return scrapeSingle(scraper, pc, args[0], asJSON, trim, maxChars)
+		return scrapeSingle(scraper, pc, args[0], asJSON, trim, maxChars, selector, noLLMSTxt)
 	}
 	return scrapeMultiple(scraper, pc, args, asJSON, trim, maxChars)
 }
@@ -81,8 +89,26 @@ func cachedScrape(s *scrape.Scraper, pc *cache.Cache, url string) (*scrape.Page,
 	return page, nil
 }
 
-func scrapeSingle(s *scrape.Scraper, pc *cache.Cache, url string, asJSON bool, trim bool, maxChars int) error {
-	page, err := cachedScrape(s, pc, url)
+func scrapeSingle(s *scrape.Scraper, pc *cache.Cache, rawURL string, asJSON bool, trim bool, maxChars int, selector string, noLLMSTxt bool) error {
+	// --select: direct fetch + CSS extraction, bypasses cache
+	if selector != "" {
+		return scrapeWithSelector(s, rawURL, asJSON, trim, maxChars, selector)
+	}
+
+	// llms.txt auto-detection for bare domains
+	if !noLLMSTxt {
+		if content, ok := fetchLLMSTxt(rawURL); ok {
+			page := &scrape.Page{URL: rawURL, Title: "llms.txt", Markdown: content}
+			page.Markdown = postProcess(page.Markdown, trim, maxChars)
+			if asJSON {
+				return json.NewEncoder(os.Stdout).Encode(page)
+			}
+			printPage(page)
+			return nil
+		}
+	}
+
+	page, err := cachedScrape(s, pc, rawURL)
 	if err != nil {
 		return fmt.Errorf("scrape failed: %w", err)
 	}
@@ -142,6 +168,75 @@ func scrapeMultiple(s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON bo
 		printPage(r.page)
 	}
 	return nil
+}
+
+func scrapeWithSelector(s *scrape.Scraper, rawURL string, asJSON bool, trim bool, maxChars int, selector string) error {
+	html, err := s.Fetch(rawURL)
+	if err != nil {
+		return fmt.Errorf("fetch failed: %w", err)
+	}
+
+	markdown, err := extract.ExtractSelector(html, selector)
+	if err != nil {
+		return fmt.Errorf("selector extraction failed: %w", err)
+	}
+	if markdown == "" {
+		return fmt.Errorf("no elements matched selector %q", selector)
+	}
+
+	title := extractTitleFromHTML(html)
+	page := &scrape.Page{URL: rawURL, Title: title, Markdown: markdown}
+	page.Markdown = postProcess(page.Markdown, trim, maxChars)
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(page)
+	}
+	printPage(page)
+	return nil
+}
+
+// extractTitleFromHTML pulls the <title> tag from raw HTML.
+func extractTitleFromHTML(html string) string {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(doc.Find("title").First().Text())
+}
+
+// fetchLLMSTxt attempts to fetch /llms.txt from the given base URL.
+// Returns the content and true if successful, empty string and false otherwise.
+// All errors are silently swallowed — this is a best-effort check.
+func fetchLLMSTxt(baseURL string) (string, bool) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", false
+	}
+	if u.Path != "" && u.Path != "/" {
+		return "", false
+	}
+
+	llmsURL := u.Scheme + "://" + u.Host + "/llms.txt"
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(llmsURL) //nolint:noctx
+	if err != nil {
+		return "", false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/plain") {
+		return "", false
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
 }
 
 func printPage(p *scrape.Page) {

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -57,7 +57,7 @@ func (e *Extractor) Extract(pageURL, html string) (*Result, error) {
 // extractRaw converts the full HTML to markdown without readability.
 // Noisier output (includes nav, footer, etc.) but never fails on valid HTML.
 func extractRaw(html string) (*Result, error) {
-	title := extractTitle(html)
+	title := Title(html)
 
 	markdown, err := md.ConvertString(html)
 	if err != nil {
@@ -114,8 +114,8 @@ func ExtractSelector(rawHTML, selector string) (string, error) {
 	return strings.TrimSpace(markdown), nil
 }
 
-// extractTitle pulls the <title> tag content from raw HTML.
-func extractTitle(html string) string {
+// Title pulls the <title> tag content from raw HTML.
+func Title(html string) string {
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
 	if err != nil {
 		return ""

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -75,6 +75,45 @@ func extractRaw(html string) (*Result, error) {
 	}, nil
 }
 
+// ExtractSelector runs a CSS selector against raw HTML and returns the
+// matched elements converted to markdown. If no elements match, returns
+// an empty string and no error.
+func ExtractSelector(rawHTML, selector string) (string, error) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(rawHTML))
+	if err != nil {
+		return "", err
+	}
+
+	sel := doc.Find(selector)
+	if sel.Length() == 0 {
+		return "", nil
+	}
+
+	var parts []string
+	var outerErr error
+	sel.Each(func(_ int, s *goquery.Selection) {
+		if outerErr != nil {
+			return
+		}
+		h, err := goquery.OuterHtml(s)
+		if err != nil {
+			outerErr = err
+			return
+		}
+		parts = append(parts, h)
+	})
+	if outerErr != nil {
+		return "", outerErr
+	}
+
+	html := strings.Join(parts, "\n\n")
+	markdown, err := md.ConvertString(html)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(markdown), nil
+}
+
 // extractTitle pulls the <title> tag content from raw HTML.
 func extractTitle(html string) string {
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -100,7 +100,7 @@ func (s *Scraper) getBrowser() BrowserConn {
 // If the page appears JS-rendered and a browser is configured, automatically
 // retries with the browser for full content extraction.
 func (s *Scraper) Scrape(rawURL string) (*Page, error) {
-	body, err := s.fetch(rawURL)
+	body, err := s.Fetch(rawURL)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,8 @@ func ContentHash(s string) string {
 	return hex.EncodeToString(h[:])[:16]
 }
 
-func (s *Scraper) fetch(rawURL string) (string, error) {
+// Fetch fetches the raw HTML for a URL without extraction or browser fallback.
+func (s *Scraper) Fetch(rawURL string) (string, error) {
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {
 		return "", err

--- a/internal/scrape/scrape.go
+++ b/internal/scrape/scrape.go
@@ -105,7 +105,7 @@ func (s *Scraper) Scrape(rawURL string) (*Page, error) {
 		return nil, err
 	}
 
-	body = s.maybeBrowserFetch(rawURL, body)
+	body = s.MaybeBrowserFetch(rawURL, body)
 
 	result, err := s.extractor.Extract(rawURL, body)
 	if err != nil {
@@ -202,7 +202,9 @@ func (s *Scraper) BrowserScrape(rawURL string) (*Page, string, error) {
 	return page, html, nil
 }
 
-func (s *Scraper) maybeBrowserFetch(rawURL, html string) string {
+// MaybeBrowserFetch re-fetches rawURL via the browser if html looks JS-rendered.
+// Returns the original html if no browser is needed or available.
+func (s *Scraper) MaybeBrowserFetch(rawURL, html string) string {
 	detection := extract.DetectJSShell(html)
 	if detection != "likely_shell" {
 		return html


### PR DESCRIPTION
## Summary

- **`--select <css>`**: Extract specific page sections using CSS selectors, bypassing readability extraction and caching. Useful for grabbing just the content you need (e.g., `ketch scrape https://example.com --select "article.main"`)
- **`llms.txt` auto-detection**: For bare domain URLs (e.g., `https://example.com`), automatically checks for `/llms.txt` and returns it directly if found. Disable with `--no-llms-txt` (e.g., `ketch scrape https://anthropic.com --no-llms-txt`)
- **`Scraper.Fetch()` exported**: The raw HTML fetch method is now exported for use by other packages and future features

### Examples

```bash
# Extract only <article> elements from a page
ketch scrape https://example.com --select "article"

# Extract specific class, with trimming
ketch scrape https://example.com --select ".docs-content" --trim

# Selector + JSON output + truncation
ketch scrape https://example.com --select "h2, h3" --json --max-chars 500

# Auto-detect llms.txt on bare domains (default behavior)
ketch scrape https://anthropic.com
# → returns /llms.txt content if available

# Disable llms.txt detection
ketch scrape https://anthropic.com --no-llms-txt
# → falls through to normal scrape pipeline
```

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `golangci-lint run` passes (0 issues)
- [ ] `--select` with matching selector returns extracted markdown
- [ ] `--select` with non-matching selector returns clear error
- [ ] `--select` composes with `--trim` and `--max-chars`
- [ ] `--select` bypasses cache (verified by not appearing in cache stats)
- [ ] Bare domain auto-fetches `/llms.txt` when available
- [ ] Non-bare-domain URLs skip llms.txt check
- [ ] `--no-llms-txt` disables the auto-detection
- [ ] `Scraper.Fetch()` is callable from external packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)