### PR TITLE
feat: smart multi-URL scraping + bounded concurrency + context plumbing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ internal/
 - **Concurrent by default**: multiple URLs scraped in parallel via goroutines.
 - **Operator configures, agent consumes**: config sets defaults (backend, browser, cache TTL) so agents don't need to know infrastructure.
 - **Three search surfaces**: `ketch search` finds web pages, `ketch code` greps real OSS code, `ketch docs` fetches library documentation. Each has its own backend interface and Result type — they never share backends.
+- **Smart input detection on scrape**: single URL, multiple positional args, JSON array string, file path, or stdin pipe all work — ketch routes automatically. No --batch flag needed.
+- **Context-aware interfaces**: all three Searcher interfaces (`search`, `code`, `docs`) take `context.Context` as first param for cancellation and timeout propagation.
 
 ## Quality Standards
 
@@ -75,6 +77,9 @@ ketch search "query" --scrape               # search + fetch full content
 ketch search "query" -b searxng             # use SearXNG backend
 ketch scrape <url>                          # single URL → markdown
 ketch scrape <url1> <url2> <url3>           # concurrent batch scrape
+ketch scrape urls.txt                       # file with one URL per line
+ketch scrape '["url1","url2"]'              # JSON array of URLs
+echo "url1\nurl2" | ketch scrape            # stdin pipe
 ketch crawl <url>                           # BFS crawl
 ketch crawl <url> --sitemap                 # sitemap-based crawl
 ketch crawl <url> --background              # run in background
@@ -118,3 +123,4 @@ ketch cache                                 # show cache stats
 | --minimal | search, code, docs | false | One result per line, tab-separated, no frontmatter |
 | --select \<css\> | scrape | — | Extract only elements matching CSS selector (skips readability) |
 | --no-llms-txt | scrape | false | Disable automatic /llms.txt detection for bare domains |
+| --concurrency | scrape | 5 | Max concurrent requests for multi-URL scraping |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,16 @@ Default output uses YAML frontmatter + markdown (cymbal style):
 | `--select <css>` | scrape | — | Extract only elements matching CSS selector (skips readability) |
 | `--no-llms-txt` | scrape | false | Disable automatic /llms.txt detection for bare domains |
 
+### Multi-URL Scraping
+ketch scrape detects input mode automatically — no flags needed:
+- Multiple args:  ketch scrape url1 url2 url3
+- JSON array:     ketch scrape '["url1","url2"]'
+- File:           ketch scrape urls.txt
+- Stdin pipe:     echo "url1\nurl2" | ketch scrape
+- Single:         ketch scrape url
+
+Use --concurrency N (default 5) to control parallel request limit.
+
 ### Search Backends (ketch search)
 
 | Backend | Setup | Notes |

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -40,11 +40,11 @@ func runDocs(cmd *cobra.Command, args []string) error {
 	minimal, _ := cmd.Flags().GetBool("minimal")
 
 	if resolve {
-		return runDocsResolve(query, asJSON)
+		return runDocsResolve(cmd, query, asJSON)
 	}
 
 	if library != "" && backend == "context7" {
-		return runDocsWithLibrary(query, library, tokens, asJSON, minimal)
+		return runDocsWithLibrary(cmd, query, library, tokens, asJSON, minimal)
 	}
 
 	searcher, err := newDocSearcher(backend)
@@ -52,7 +52,7 @@ func runDocs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	results, err := searcher.Search(query, limit)
+	results, err := searcher.Search(cmd.Context(), query, limit)
 	if err != nil {
 		return fmt.Errorf("docs search failed: %w", err)
 	}
@@ -65,13 +65,13 @@ func runDocs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runDocsResolve(query string, asJSON bool) error {
+func runDocsResolve(cmd *cobra.Command, query string, asJSON bool) error {
 	if cfg.Context7APIKey == "" {
 		return fmt.Errorf("context7: API key not set (get one then: ketch config set context7_api_key <key>)")
 	}
 
 	c7 := docs.NewContext7(cfg.Context7APIKey)
-	matches, err := c7.ResolveLibrary(query)
+	matches, err := c7.ResolveLibrary(cmd.Context(), query)
 	if err != nil {
 		return fmt.Errorf("resolve failed: %w", err)
 	}
@@ -86,13 +86,13 @@ func runDocsResolve(query string, asJSON bool) error {
 	return nil
 }
 
-func runDocsWithLibrary(query, library string, tokens int, asJSON bool, minimal bool) error {
+func runDocsWithLibrary(cmd *cobra.Command, query, library string, tokens int, asJSON bool, minimal bool) error {
 	if cfg.Context7APIKey == "" {
 		return fmt.Errorf("context7: API key not set (get one then: ketch config set context7_api_key <key>)")
 	}
 
 	c7 := docs.NewContext7(cfg.Context7APIKey)
-	results, err := c7.GetDocs(library, query, tokens)
+	results, err := c7.GetDocs(cmd.Context(), library, query, tokens)
 	if err != nil {
 		return fmt.Errorf("docs fetch failed: %w", err)
 	}

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,11 +20,17 @@ import (
 )
 
 var scrapeCmd = &cobra.Command{
-	Use:   "scrape <url> [urls...]",
+	Use:   "scrape [url...] | [file] | [json-array]",
 	Short: "Scrape URLs and extract clean markdown",
-	Long:  `Fetch one or more URLs, extract the main content, and convert to clean markdown. Multiple URLs are scraped concurrently.`,
-	Args:  cobra.MinimumNArgs(1),
-	RunE:  runScrape,
+	Long: `Fetch one or more URLs, extract the main content, and convert to clean markdown.
+
+Input is detected automatically:
+  Multiple args:  ketch scrape url1 url2 url3
+  JSON array:     ketch scrape '["url1","url2"]'
+  File:           ketch scrape urls.txt
+  Stdin pipe:     echo "url1\nurl2" | ketch scrape
+  Single URL:     ketch scrape url`,
+	RunE: runScrape,
 }
 
 func init() {
@@ -34,6 +41,7 @@ func init() {
 	scrapeCmd.Flags().Bool("trim", false, "strip markdown formatting, keep content text only")
 	scrapeCmd.Flags().String("select", "", "CSS selector to extract specific elements (skips readability)")
 	scrapeCmd.Flags().Bool("no-llms-txt", false, "disable automatic /llms.txt detection for bare domains")
+	scrapeCmd.Flags().Int("concurrency", 5, "max concurrent requests for multi-URL scraping")
 }
 
 func runScrape(cmd *cobra.Command, args []string) error {
@@ -43,6 +51,12 @@ func runScrape(cmd *cobra.Command, args []string) error {
 	trim, _ := cmd.Flags().GetBool("trim")
 	selector, _ := cmd.Flags().GetString("select")
 	noLLMSTxt, _ := cmd.Flags().GetBool("no-llms-txt")
+	concurrency, _ := cmd.Flags().GetInt("concurrency")
+
+	urls, err := resolveURLs(args)
+	if err != nil {
+		return err
+	}
 
 	var scraper *scrape.Scraper
 	if cfg.Browser != "" {
@@ -55,10 +69,84 @@ func runScrape(cmd *cobra.Command, args []string) error {
 	pc := newPageCache(noCache)
 	defer pc.Close()
 
-	if len(args) == 1 {
-		return scrapeSingle(scraper, pc, args[0], asJSON, trim, maxChars, selector, noLLMSTxt)
+	if len(urls) == 1 {
+		return scrapeSingle(scraper, pc, urls[0], asJSON, trim, maxChars, selector, noLLMSTxt)
 	}
-	return scrapeMultiple(scraper, pc, args, asJSON, trim, maxChars)
+	return scrapeMultiple(scraper, pc, urls, asJSON, trim, maxChars, selector, noLLMSTxt, concurrency)
+}
+
+// resolveURLs detects the input mode and returns a list of URLs.
+func resolveURLs(args []string) ([]string, error) {
+	if len(args) > 1 {
+		return args, nil
+	}
+
+	if stdinIsPipe() {
+		urls := readLines(os.Stdin)
+		if len(urls) > 0 {
+			return urls, nil
+		}
+	}
+
+	if len(args) == 1 {
+		arg := args[0]
+		if strings.HasPrefix(strings.TrimSpace(arg), "[") {
+			var urls []string
+			if err := json.Unmarshal([]byte(arg), &urls); err != nil {
+				return nil, fmt.Errorf("failed to parse JSON array: %w", err)
+			}
+			if len(urls) == 0 {
+				return nil, fmt.Errorf("JSON array is empty")
+			}
+			return urls, nil
+		}
+		if _, err := os.Stat(arg); err == nil {
+			urls, err := readLinesFromFile(arg)
+			if err != nil {
+				return nil, err
+			}
+			if len(urls) == 0 {
+				return nil, fmt.Errorf("file %q contains no URLs", arg)
+			}
+			return urls, nil
+		}
+		return []string{arg}, nil
+	}
+
+	return nil, fmt.Errorf("provide a URL, file path, JSON array, or pipe URLs via stdin")
+}
+
+// stdinIsPipe returns true when stdin is a pipe (not a terminal).
+func stdinIsPipe() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+// readLines reads all non-empty, non-comment lines from r.
+func readLines(r io.Reader) []string {
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// readLinesFromFile opens a file and returns non-empty, non-comment lines.
+func readLinesFromFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return readLines(f), nil
 }
 
 // newPageCache creates a cache from config, or nil if disabled.
@@ -122,7 +210,7 @@ func scrapeSingle(s *scrape.Scraper, pc *cache.Cache, rawURL string, asJSON bool
 	return nil
 }
 
-func scrapeMultiple(s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON bool, trim bool, maxChars int) error {
+func scrapeMultiple(s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON, trim bool, maxChars int, selector string, noLLMSTxt bool, concurrency int) error {
 	type indexedPage struct {
 		idx  int
 		page *scrape.Page
@@ -131,12 +219,16 @@ func scrapeMultiple(s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON bo
 
 	results := make([]indexedPage, len(urls))
 	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
 
 	for i, u := range urls {
 		wg.Add(1)
-		go func(idx int, url string) {
+		sem <- struct{}{}
+		go func(idx int, rawURL string) {
 			defer wg.Done()
-			page, err := cachedScrape(s, pc, url)
+			defer func() { <-sem }()
+
+			page, err := scrapeOneURL(s, pc, rawURL, selector, noLLMSTxt)
 			results[idx] = indexedPage{idx: idx, page: page, err: err}
 		}(i, u)
 	}
@@ -167,6 +259,39 @@ func scrapeMultiple(s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON bo
 		printPage(r.page)
 	}
 	return nil
+}
+
+// scrapeOneURL handles a single URL within scrapeMultiple, applying selector
+// and llms.txt detection the same way scrapeSingle does.
+func scrapeOneURL(s *scrape.Scraper, pc *cache.Cache, rawURL, selector string, noLLMSTxt bool) (*scrape.Page, error) {
+	if selector != "" {
+		return scrapeURLWithSelector(s, rawURL, selector)
+	}
+	if !noLLMSTxt {
+		if content, ok := fetchLLMSTxt(rawURL); ok {
+			return &scrape.Page{URL: rawURL, Title: "llms.txt", Markdown: content}, nil
+		}
+	}
+	return cachedScrape(s, pc, rawURL)
+}
+
+// scrapeURLWithSelector fetches a URL and extracts content matching a CSS selector.
+// Returns a Page without post-processing (caller applies trim/maxChars).
+func scrapeURLWithSelector(s *scrape.Scraper, rawURL, selector string) (*scrape.Page, error) {
+	html, err := s.Fetch(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch failed: %w", err)
+	}
+	html = s.MaybeBrowserFetch(rawURL, html)
+	markdown, err := extract.ExtractSelector(html, selector)
+	if err != nil {
+		return nil, fmt.Errorf("selector extraction failed: %w", err)
+	}
+	if markdown == "" {
+		return nil, fmt.Errorf("no elements matched selector %q", selector)
+	}
+	title := extract.Title(html)
+	return &scrape.Page{URL: rawURL, Title: title, Markdown: markdown}, nil
 }
 
 func scrapeWithSelector(s *scrape.Scraper, rawURL string, asJSON bool, trim bool, maxChars int, selector string) error {

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -76,16 +76,11 @@ func runScrape(cmd *cobra.Command, args []string) error {
 }
 
 // resolveURLs detects the input mode and returns a list of URLs.
+// Explicit args always take priority over stdin so that
+// `ketch scrape url < file` uses the URL, not the file.
 func resolveURLs(args []string) ([]string, error) {
 	if len(args) > 1 {
 		return args, nil
-	}
-
-	if stdinIsPipe() {
-		urls := readLines(os.Stdin)
-		if len(urls) > 0 {
-			return urls, nil
-		}
 	}
 
 	if len(args) == 1 {
@@ -111,6 +106,14 @@ func resolveURLs(args []string) ([]string, error) {
 			return urls, nil
 		}
 		return []string{arg}, nil
+	}
+
+	// No args — fall back to stdin if it's a pipe.
+	if stdinIsPipe() {
+		urls := readLines(os.Stdin)
+		if len(urls) > 0 {
+			return urls, nil
+		}
 	}
 
 	return nil, fmt.Errorf("provide a URL, file path, JSON array, or pipe URLs via stdin")
@@ -295,27 +298,11 @@ func scrapeURLWithSelector(s *scrape.Scraper, rawURL, selector string) (*scrape.
 }
 
 func scrapeWithSelector(s *scrape.Scraper, rawURL string, asJSON bool, trim bool, maxChars int, selector string) error {
-	html, err := s.Fetch(rawURL)
+	page, err := scrapeURLWithSelector(s, rawURL, selector)
 	if err != nil {
-		return fmt.Errorf("fetch failed: %w", err)
+		return err
 	}
-
-	// Apply browser fallback for JS-rendered pages before running the selector,
-	// otherwise the selector matches against the empty shell, not the real content.
-	html = s.MaybeBrowserFetch(rawURL, html)
-
-	markdown, err := extract.ExtractSelector(html, selector)
-	if err != nil {
-		return fmt.Errorf("selector extraction failed: %w", err)
-	}
-	if markdown == "" {
-		return fmt.Errorf("no elements matched selector %q", selector)
-	}
-
-	title := extract.Title(html)
-	page := &scrape.Page{URL: rawURL, Title: title, Markdown: markdown}
 	page.Markdown = postProcess(page.Markdown, trim, maxChars)
-
 	if asJSON {
 		return json.NewEncoder(os.Stdout).Encode(page)
 	}

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -45,7 +45,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	results, err := searcher.Search(query, limit)
+	results, err := searcher.Search(cmd.Context(), query, limit)
 	if err != nil {
 		return fmt.Errorf("search failed: %w", err)
 	}

--- a/internal/docs/context7.go
+++ b/internal/docs/context7.go
@@ -1,6 +1,7 @@
 package docs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -56,8 +57,8 @@ type context7InfoSnippet struct {
 }
 
 // Search resolves a library from the query and fetches documentation.
-func (c *Context7) Search(query string, limit int) ([]Result, error) {
-	libs, err := c.ResolveLibrary(query)
+func (c *Context7) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	libs, err := c.ResolveLibrary(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("context7 resolve failed: %w", err)
 	}
@@ -65,14 +66,14 @@ func (c *Context7) Search(query string, limit int) ([]Result, error) {
 		return nil, fmt.Errorf("context7: no library found for %q", query)
 	}
 
-	return c.GetDocs(libs[0].ID, query, 4000)
+	return c.GetDocs(ctx, libs[0].ID, query, 4000)
 }
 
 // ResolveLibrary searches Context7 for libraries matching the given name.
-func (c *Context7) ResolveLibrary(name string) ([]LibraryMatch, error) {
+func (c *Context7) ResolveLibrary(ctx context.Context, name string) ([]LibraryMatch, error) {
 	u := fmt.Sprintf("https://context7.com/api/v1/search?q=%s", url.QueryEscape(name))
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,11 +101,11 @@ func (c *Context7) ResolveLibrary(name string) ([]LibraryMatch, error) {
 }
 
 // GetDocs fetches documentation snippets for a resolved library ID.
-func (c *Context7) GetDocs(libraryID, query string, tokens int) ([]Result, error) {
+func (c *Context7) GetDocs(ctx context.Context, libraryID, query string, tokens int) ([]Result, error) {
 	u := fmt.Sprintf("https://context7.com/api/v2/context?libraryId=%s&query=%s&type=json&tokens=%d",
 		url.QueryEscape(libraryID), url.QueryEscape(query), tokens)
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1,5 +1,7 @@
 package docs
 
+import "context"
+
 // Result is a single docs search result.
 type Result struct {
 	Library    string `json:"library"`
@@ -13,5 +15,5 @@ type Result struct {
 
 // Searcher is the interface for docs backends.
 type Searcher interface {
-	Search(query string, limit int) ([]Result, error)
+	Search(ctx context.Context, query string, limit int) ([]Result, error)
 }

--- a/internal/docs/fts5.go
+++ b/internal/docs/fts5.go
@@ -1,6 +1,9 @@
 package docs
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // FTS5Local is a planned local SQLite FTS5 docs backend. Not yet implemented.
 type FTS5Local struct{}
@@ -9,6 +12,6 @@ type FTS5Local struct{}
 func NewFTS5Local() *FTS5Local { return &FTS5Local{} }
 
 // Search returns an error because the local FTS5 backend is not yet implemented.
-func (f *FTS5Local) Search(_ string, _ int) ([]Result, error) {
+func (f *FTS5Local) Search(_ context.Context, _ string, _ int) ([]Result, error) {
 	return nil, fmt.Errorf("local fts5 backend not yet implemented")
 }

--- a/internal/search/brave.go
+++ b/internal/search/brave.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,11 +35,11 @@ type braveResult struct {
 }
 
 // Search queries Brave and returns up to limit results.
-func (b *Brave) Search(query string, limit int) ([]Result, error) {
+func (b *Brave) Search(ctx context.Context, query string, limit int) ([]Result, error) {
 	u := fmt.Sprintf("https://api.search.brave.com/res/v1/web/search?q=%s&count=%d&text_decorations=false&result_filter=web",
 		url.QueryEscape(query), limit)
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/ddg.go
+++ b/internal/search/ddg.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,8 +22,8 @@ func NewDDG() *DDG {
 }
 
 // Search queries DuckDuckGo and returns up to limit results.
-func (d *DDG) Search(query string, limit int) ([]Result, error) {
-	resp, err := d.fetchResults(query)
+func (d *DDG) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	resp, err := d.fetchResults(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -62,10 +63,10 @@ func (d *DDG) Search(query string, limit int) ([]Result, error) {
 
 const ddgUA = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
 
-func (d *DDG) fetchResults(query string) (*http.Response, error) {
+func (d *DDG) fetchResults(ctx context.Context, query string) (*http.Response, error) {
 	u := fmt.Sprintf("https://html.duckduckgo.com/html/?q=%s", url.QueryEscape(query))
 	for range 3 {
-		req, err := http.NewRequest("GET", u, nil)
+		req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,5 +1,7 @@
 package search
 
+import "context"
+
 // Result represents a single search result.
 type Result struct {
 	Title       string `json:"title"`
@@ -10,5 +12,5 @@ type Result struct {
 
 // Searcher is the interface for search backends.
 type Searcher interface {
-	Search(query string, limit int) ([]Result, error)
+	Search(ctx context.Context, query string, limit int) ([]Result, error)
 }

--- a/internal/search/search_feature_test.go
+++ b/internal/search/search_feature_test.go
@@ -1,0 +1,303 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestFeatureBraveSearchParses(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Subscription-Token") == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"web": {
+				"results": [
+					{"title": "Go Docs", "url": "https://golang.org/doc/", "description": "Go documentation"},
+					{"title": "Go Blog", "url": "https://blog.golang.org/", "description": "The Go Blog"},
+					{"title": "Go Playground", "url": "https://play.golang.org/", "description": "Run Go online"}
+				]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	b := &Brave{apiKey: "test-key", client: server.Client()}
+	// Override URL by using the test server — need to patch the search method
+	// Instead, we'll create a custom transport
+	b.client = &http.Client{Transport: &rewriteTransport{base: server.Client().Transport, target: server.URL}}
+
+	results, err := b.Search(context.Background(), "golang", 3)
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("got %d results, want 3", len(results))
+	}
+	if results[0].Title != "Go Docs" {
+		t.Errorf("first result title = %q, want %q", results[0].Title, "Go Docs")
+	}
+	if results[0].URL != "https://golang.org/doc/" {
+		t.Errorf("first result URL = %q, want %q", results[0].URL, "https://golang.org/doc/")
+	}
+	if results[0].Description != "Go documentation" {
+		t.Errorf("first result desc = %q, want %q", results[0].Description, "Go documentation")
+	}
+}
+
+func TestFeatureBraveSearch401(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	b := &Brave{apiKey: "bad-key", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := b.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	// Error should mention API key
+	if got := err.Error(); got == "" {
+		t.Error("error message should not be empty")
+	}
+}
+
+func TestFeatureBraveLimitRespected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"web": {
+				"results": [
+					{"title": "A", "url": "https://a.com", "description": "a"},
+					{"title": "B", "url": "https://b.com", "description": "b"},
+					{"title": "C", "url": "https://c.com", "description": "c"},
+					{"title": "D", "url": "https://d.com", "description": "d"},
+					{"title": "E", "url": "https://e.com", "description": "e"}
+				]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	b := &Brave{apiKey: "key", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := b.Search(context.Background(), "test", 2)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("got %d results, want 2 (limit)", len(results))
+	}
+}
+
+func TestFeatureBraveEmptyResults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"web": {"results": []}}`)
+	}))
+	defer server.Close()
+
+	b := &Brave{apiKey: "key", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := b.Search(context.Background(), "nothing", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestFeatureDDGSearchParses(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body>
+			<div class="result">
+				<h2 class="result__title"><a class="result__a" href="https://golang.org/">Go Language</a></h2>
+				<div class="result__snippet">The Go programming language</div>
+			</div>
+			<div class="result">
+				<h2 class="result__title"><a class="result__a" href="https://go.dev/">Go Dev</a></h2>
+				<div class="result__snippet">Go developer portal</div>
+			</div>
+		</body></html>`)
+	}))
+	defer server.Close()
+
+	d := &DDG{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := d.Search(context.Background(), "golang", 10)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Title != "Go Language" {
+		t.Errorf("title = %q, want %q", results[0].Title, "Go Language")
+	}
+}
+
+func TestFeatureDDGRetryOn202(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body>
+			<div class="result">
+				<h2 class="result__title"><a class="result__a" href="https://example.com">Example</a></h2>
+				<div class="result__snippet">After retries</div>
+			</div>
+		</body></html>`)
+	}))
+	defer server.Close()
+
+	d := &DDG{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := d.Search(context.Background(), "test", 5)
+	if err != nil {
+		t.Fatalf("Search error after retries: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if attempts.Load() < 3 {
+		t.Errorf("expected at least 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestFeatureDDGLimitRespected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body>
+			<div class="result"><h2 class="result__title"><a class="result__a" href="https://a.com">A</a></h2><div class="result__snippet">a</div></div>
+			<div class="result"><h2 class="result__title"><a class="result__a" href="https://b.com">B</a></h2><div class="result__snippet">b</div></div>
+			<div class="result"><h2 class="result__title"><a class="result__a" href="https://c.com">C</a></h2><div class="result__snippet">c</div></div>
+		</body></html>`)
+	}))
+	defer server.Close()
+
+	d := &DDG{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := d.Search(context.Background(), "test", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Errorf("got %d results, want 1 (limit)", len(results))
+	}
+}
+
+func TestFeatureSearXNGSearchParses(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"results": [
+				{"title": "SearX Result 1", "url": "https://example.com/1", "content": "First result content"},
+				{"title": "SearX Result 2", "url": "https://example.com/2", "content": "Second result content"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	s := &SearXNG{baseURL: server.URL, client: server.Client()}
+	results, err := s.Search(context.Background(), "test", 10)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Title != "SearX Result 1" {
+		t.Errorf("title = %q, want %q", results[0].Title, "SearX Result 1")
+	}
+	if results[0].Description != "First result content" {
+		t.Errorf("description = %q, want %q", results[0].Description, "First result content")
+	}
+}
+
+func TestFeatureSearXNGLimitRespected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"results": [
+				{"title": "A", "url": "https://a.com", "content": "a"},
+				{"title": "B", "url": "https://b.com", "content": "b"},
+				{"title": "C", "url": "https://c.com", "content": "c"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	s := &SearXNG{baseURL: server.URL, client: server.Client()}
+	results, err := s.Search(context.Background(), "test", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("got %d results, want 2 (limit)", len(results))
+	}
+}
+
+func TestFeatureSearXNGEmptyResults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results": []}`)
+	}))
+	defer server.Close()
+
+	s := &SearXNG{baseURL: server.URL, client: server.Client()}
+	results, err := s.Search(context.Background(), "nothing", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestFeatureSearXNGServerError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	s := &SearXNG{baseURL: server.URL, client: server.Client()}
+	_, err := s.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+// rewriteTransport rewrites request URLs to point to the test server.
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point to our test server, preserving path and query
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = t.target[len("http://"):]
+	if t.base != nil {
+		return t.base.RoundTrip(req)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}

--- a/internal/search/searxng.go
+++ b/internal/search/searxng.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,10 +33,10 @@ type searxngResult struct {
 }
 
 // Search queries SearXNG and returns up to limit results.
-func (s *SearXNG) Search(query string, limit int) ([]Result, error) {
+func (s *SearXNG) Search(ctx context.Context, query string, limit int) ([]Result, error) {
 	u := fmt.Sprintf("%s/search?q=%s&format=json&pageno=1", s.baseURL, url.QueryEscape(query))
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- **Smart URL detection on `ketch scrape`** — automatically detects input mode and routes accordingly. No `--batch` flag needed:
  - Multiple positional args: `ketch scrape url1 url2 url3`
  - JSON array: `ketch scrape '["url1","url2"]'`
  - File (one URL per line): `ketch scrape urls.txt`
  - Stdin pipe: `echo "url1\nurl2" | ketch scrape`
  - Single URL: `ketch scrape url`
- **Bounded concurrency** for multi-URL scraping via `--concurrency N` (default 5), replacing unbounded goroutine-per-URL with a semaphore-based worker pool
- **`--select` and `--no-llms-txt` flags** now pass through to multi-URL scraping (previously only worked for single URL)
- **`context.Context` plumbing** added to `search.Searcher` and `docs.Searcher` interfaces, matching `code.Searcher` which already had it. All three search surfaces now consistently accept context as first param. All HTTP backends use `http.NewRequestWithContext` for proper cancellation/timeout propagation.

## Pipe chain example

```bash
ketch search "golang error handling" --json | jq -r '.[].url' | ketch scrape --trim --max-chars 2000
```

## Context plumbing

All three `Searcher` interfaces now take `context.Context` as first param:
- `search.Searcher.Search(ctx, query, limit)`
- `code.Searcher.Search(ctx, query, lang, limit)` (already had it)
- `docs.Searcher.Search(ctx, query, limit)`

## Test plan

- [x] `go build ./...` passes (CGO_ENABLED=0)
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes (0 issues, gocyclo max 15)
- [x] No new external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)