### PR TITLE
feat: add exa search backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ cmd/
   browser.go                 Browser command: install, status
   proc_unix.go               Unix process management (detach, signals)
   proc_windows.go            Windows process management stub
-search/                      Searcher interface + Brave/DDG/SearXNG backends
+search/                      Searcher interface + Brave/DDG/SearXNG/EXA backends
 code/                        code.Searcher interface + Sourcegraph/GitHub backends
 docs/                        docs.Searcher interface + Context7/FTS5 backends
 scrape/                      HTTP fetch + Page type, JS detection fallback, Rod browser
@@ -58,6 +58,7 @@ Reusable packages live at the module root so external programs can `import "gith
 ketch search "query"                        # search, return results
 ketch search "query" --scrape               # search + fetch full content
 ketch search "query" -b searxng             # use SearXNG backend
+ketch search "query" -b exa                 # use Exa hosted MCP backend
 ketch scrape <url>                          # single URL → markdown
 ketch scrape <url1> <url2> <url3>           # concurrent batch scrape
 ketch scrape urls.txt                       # file with one URL per line
@@ -84,7 +85,7 @@ ketch cache                                 # show cache stats
 | Flag | Scope | Default | Description |
 |------|-------|---------|-------------|
 | --json | global | false | JSON output |
-| --backend, -b | search | brave | Search backend (brave/ddg/searxng) |
+| --backend, -b | search | brave | Search backend (brave/ddg/searxng/exa) |
 | --limit, -l | search | 5 | Max results |
 | --scrape | search | false | Fetch full content |
 | --searxng-url | search | http://localhost:8081 | SearXNG URL |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `exa` web search backend via Exa's hosted MCP endpoint, with optional `exa_api_key` config for authenticated usage.
+
 ## [0.9.3] - 2026-05-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ See [AGENTS.md](AGENTS.md) for full module layout and design principles.
 - `cmd/` — Cobra CLI (root, search, code, docs, scrape, crawl, config, cache, browser, version)
 - `code/` — `code.Searcher` interface with Grep (default), Sourcegraph, and GitHub backends
 - `docs/` — `docs.Searcher` interface with Context7 backend (local FTS5 planned)
-- `search/` — `Searcher` interface with Brave (default), DDG, and SearXNG backends
+- `search/` — `Searcher` interface with Brave (default), DDG, SearXNG, and Exa backends
 - `scrape/` — HTTP fetch + browser fallback via Rod for JS-rendered pages
 - `extract/` — readability + html-to-markdown pipeline, JS shell detection heuristic
 - `crawl/` — BFS/sitemap crawler with background execution and status tracking
@@ -59,6 +59,7 @@ Use --concurrency N (default 5) to control parallel request limit.
 | `brave` (default) | Free API key from brave.com/search/api | Stable JSON API |
 | `ddg` | Zero config | Rate-limited by DDG currently |
 | `searxng` | Self-hosted instance | Most reliable for heavy use |
+| `exa` | Zero config via hosted MCP; optional `ketch config set exa_api_key <key>` | AI-oriented search with snippets/content from Exa |
 
 ### Code Backends (ketch code)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ketch scrape https://example.com --json
 
 | Command | What it does |
 |---------|-------------|
-| `search` | Web search via Brave, DuckDuckGo, or SearXNG, optional `--scrape` for full content |
+| `search` | Web search via Brave, DuckDuckGo, SearXNG, or Exa, optional `--scrape` for full content |
 | `code` | Code search across OSS via Grep (default), Sourcegraph, or GitHub Code Search |
 | `docs` | Library/framework docs via Context7 (curated, version-aware snippets) |
 | `scrape` | Fetch URLs and extract clean markdown, concurrent batch support |
@@ -204,7 +204,7 @@ ketch config
   "docs_backend": "context7",
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "gh-cli",
-  "available_backends": ["brave", "ddg", "searxng"],
+  "available_backends": ["brave", "ddg", "searxng", "exa"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7", "local"]
 }
@@ -217,6 +217,7 @@ ketch config
 | `brave` (default) | Free API key from brave.com/search/api | Stable JSON API |
 | `ddg` | Zero config | Rate-limited by DDG currently |
 | `searxng` | Self-hosted instance | Most reliable for heavy use |
+| `exa` | Zero config via hosted MCP; optional `ketch config set exa_api_key <key>` | AI-oriented search with snippets/content from Exa |
 
 ### Code Backends (ketch code)
 
@@ -277,7 +278,7 @@ Use `ketch` CLI for all external research — web pages, OSS code, library docs.
 
 ### Why this works
 
-An agent calling a web search API typically needs to know which provider to use, manage API keys, and handle provider-specific response formats. ketch collapses that: the operator runs `ketch config set backend searxng` (or `ketch config set code_backend github`, `ketch config set docs_backend context7`) once, and every agent invocation uses the right backend automatically. The agent's system prompt doesn't mention backends at all — it just says "use ketch."
+An agent calling a web search API typically needs to know which provider to use, manage API keys, and handle provider-specific response formats. ketch collapses that: the operator runs `ketch config set backend exa` (or `ketch config set code_backend github`, `ketch config set docs_backend context7`) once, and every agent invocation uses the right backend automatically. The agent's system prompt doesn't mention backends at all — it just says "use ketch."
 
 `ketch config` returns the full discovery payload as JSON — including which search, code, and docs backends are active and which token source is in effect — so an agent that needs to inspect capabilities can do so in one call without parsing help text.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -132,6 +132,8 @@ func applyConfigSet(c *config.Config, key, value string) error {
 		c.SearxngURL = value
 	case "brave_api_key":
 		c.BraveAPIKey = value
+	case "exa_api_key":
+		c.ExaAPIKey = value
 	case "limit":
 		return setLimit(c, value)
 	case "cache_ttl":
@@ -151,7 +153,7 @@ func applyConfigSet(c *config.Config, key, value string) error {
 	case "url_rewrites":
 		return setURLRewrites(c, value)
 	default:
-		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites)", key)
+		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, exa_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites)", key)
 	}
 	return nil
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -17,7 +17,7 @@ import (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search the web and return results",
-	Long:  `Search the web using Brave (default), DuckDuckGo, or SearXNG. Add --scrape to fetch and extract full content from results.`,
+	Long:  `Search the web using Brave (default), DuckDuckGo, SearXNG, or Exa. Add --scrape to fetch and extract full content from results.`,
 	Args:  exitArgs(cobra.MinimumNArgs(1)),
 	RunE:  runSearch,
 }
@@ -159,6 +159,12 @@ func newSearcher(cmd *cobra.Command, backend string) (search.Searcher, error) {
 		return search.NewSearXNG(url), nil
 	case "ddg":
 		return search.NewDDG(), nil
+	case "exa":
+		var apiKey *string
+		if cfg.ExaAPIKey != "" {
+			apiKey = &cfg.ExaAPIKey
+		}
+		return search.NewEXA(apiKey), nil
 	default:
 		return nil, exitErrf(ExitValidation, "unknown backend: %s", backend)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Backend        string            `json:"backend"`
 	SearxngURL     string            `json:"searxng_url"`
 	BraveAPIKey    string            `json:"brave_api_key,omitempty"`
+	ExaAPIKey      string            `json:"exa_api_key,omitempty"`
 	Limit          int               `json:"limit"`
 	CacheTTL       string            `json:"cache_ttl"`
 	Browser        string            `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
@@ -69,7 +70,7 @@ func Defaults() Config {
 
 // AvailableBackends returns the list of known search backends.
 func AvailableBackends() []string {
-	return []string{"brave", "ddg", "searxng"}
+	return []string{"brave", "ddg", "searxng", "exa"}
 }
 
 // AvailableCodeBackends returns the list of known code search backends.

--- a/search/exa.go
+++ b/search/exa.go
@@ -1,0 +1,147 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/1broseidon/ketch/httpx"
+)
+
+type EXA struct {
+	apiKey *string
+	client *http.Client
+}
+
+func NewEXA(apiKey *string) *EXA {
+	return &EXA{
+		apiKey: apiKey,
+		client: httpx.Default(),
+	}
+}
+
+func (e *EXA) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	// Step 1 : Build request body:
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "web_search_exa",
+			"arguments": map[string]any{
+				"query":                query,
+				"numResults":           limit,
+				"type":                 "auto",
+				"livecrawl":            "fallback",
+				"contextMaxCharacters": 3000,
+			},
+		},
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2 : Send this request to EXA
+	endpoint := "https://mcp.exa.ai/mcp"
+	if e.apiKey != nil && strings.TrimSpace(*e.apiKey) != "" {
+		v := url.Values{}
+		v.Set("exaApiKey", strings.TrimSpace(*e.apiKey))
+		endpoint += "?" + v.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(encoded))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("exa request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("exa returned status %d", resp.StatusCode)
+	}
+
+	// Step 3 : Parse the SSE-like response
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read exa response: %w", err)
+	}
+	var payload string
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data:") {
+			payload = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		}
+	}
+	if payload == "" {
+		return nil, fmt.Errorf("exa response contained no data payload")
+	}
+
+	var parsed struct {
+		Result struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to decode exa response: %w", err)
+	}
+
+	// Step 4 : Populate response and return
+	results := make([]Result, 0, limit)
+	for _, content := range parsed.Result.Content {
+		if content.Type != "text" || len(results) >= limit {
+			continue
+		}
+		remaining := limit - len(results)
+		results = append(results, parseContent(content.Text, remaining)...)
+	}
+
+	return results, nil
+}
+
+// parseContent converts Exa's text-formatted MCP search output into structured
+// results. Exa returns result blocks separated by "---", with metadata lines
+// such as "Title:" and "URL:" followed by highlight text. This parser extracts
+// the title, URL, highlight text as content, and the first plain highlight
+// line as the description.
+func parseContent(rawContent string, limit int) []Result {
+	results := make([]Result, 0, limit)
+	for block := range strings.SplitSeq(rawContent, "\n---\n") {
+		if len(results) >= limit {
+			break
+		}
+		var result Result
+		var contentLines []string
+		for line := range strings.SplitSeq(block, "\n") {
+			line = strings.TrimSpace(line)
+			switch {
+			case strings.HasPrefix(line, "Title:"):
+				result.Title = strings.TrimSpace(strings.TrimPrefix(line, "Title:"))
+			case strings.HasPrefix(line, "URL:"):
+				result.URL = strings.TrimSpace(strings.TrimPrefix(line, "URL:"))
+			case line != "" && !strings.Contains(line, ":"):
+				contentLines = append(contentLines, line)
+				if result.Description == "" {
+					result.Description = line
+				}
+			}
+		}
+		result.Content = strings.Join(contentLines, "\n")
+		if result.Title != "" && result.URL != "" {
+			results = append(results, result)
+		}
+	}
+	return results
+}

--- a/search/search_feature_test.go
+++ b/search/search_feature_test.go
@@ -2,9 +2,11 @@ package search
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -282,6 +284,152 @@ func TestFeatureSearXNGServerError(t *testing.T) {
 	_, err := s.Search(context.Background(), "test", 5)
 	if err == nil {
 		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestFeatureEXASearchParses(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `event: message
+`)
+		fmt.Fprint(w, `data: {"result":{"content":[{"type":"text","text":"Title: Rust Programming Language\nURL: https://www.rust-lang.org/\nHighlights:\nRust is a programming language.\n\n---\n\nTitle: Rust Releases\nURL: https://blog.rust-lang.org/\nHighlights:\nRelease notes for Rust."}]}}
+`)
+	}))
+	defer server.Close()
+
+	e := &EXA{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := e.Search(context.Background(), "rust", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Title != "Rust Programming Language" {
+		t.Errorf("title = %q, want %q", results[0].Title, "Rust Programming Language")
+	}
+	if results[0].URL != "https://www.rust-lang.org/" {
+		t.Errorf("url = %q, want %q", results[0].URL, "https://www.rust-lang.org/")
+	}
+	if results[0].Description != "Rust is a programming language." {
+		t.Errorf("description = %q, want %q", results[0].Description, "Rust is a programming language.")
+	}
+	if !strings.Contains(results[0].Content, "Rust is a programming language.") {
+		t.Errorf("content = %q, want rust highlight", results[0].Content)
+	}
+}
+
+func TestFeatureEXALimitRespected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `event: message
+`)
+		fmt.Fprint(w, `data: {"result":{"content":[{"type":"text","text":"Title: A\nURL: https://a.com\nHighlights:\na\n\n---\n\nTitle: B\nURL: https://b.com\nHighlights:\nb\n\n---\n\nTitle: C\nURL: https://c.com\nHighlights:\nc"}]}}
+`)
+	}))
+	defer server.Close()
+
+	e := &EXA{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := e.Search(context.Background(), "rust", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("got %d results, want 2 (limit)", len(results))
+	}
+}
+
+func TestFeatureEXAEmptyResults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `event: message
+`)
+		fmt.Fprint(w, `data: {"result":{"content":[{"type":"text","text":""}]}}
+`)
+	}))
+	defer server.Close()
+
+	e := &EXA{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := e.Search(context.Background(), "nothing", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestFeatureEXAServerError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	e := &EXA{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := e.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestFeatureEXARequestShape(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		params := body["params"].(map[string]any)
+		arguments := params["arguments"].(map[string]any)
+		if body["method"] != "tools/call" {
+			t.Errorf("method = %q, want tools/call", body["method"])
+		}
+		if params["name"] != "web_search_exa" {
+			t.Errorf("tool name = %q, want web_search_exa", params["name"])
+		}
+		if arguments["query"] != "rust release date" {
+			t.Errorf("query = %q, want rust release date", arguments["query"])
+		}
+		if arguments["numResults"] != float64(5) {
+			t.Errorf("numResults = %v, want 5", arguments["numResults"])
+		}
+		if arguments["livecrawl"] != "fallback" {
+			t.Errorf("livecrawl = %q, want fallback", arguments["livecrawl"])
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"result":{"content":[{"type":"text","text":"Title: Rust\nURL: https://www.rust-lang.org/\nHighlights:\nRust"}]}}
+`)
+	}))
+	defer server.Close()
+
+	e := &EXA{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := e.Search(context.Background(), "rust release date", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+}
+
+func TestFeatureEXAAPIKeyAdded(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("exaApiKey"); got != "test-key" {
+			t.Errorf("exaApiKey = %q, want test-key", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"result":{"content":[{"type":"text","text":"Title: Rust\nURL: https://www.rust-lang.org/\nHighlights:\nRust"}]}}
+`)
+	}))
+	defer server.Close()
+
+	key := "test-key"
+	e := &EXA{apiKey: &key, client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := e.Search(context.Background(), "rust", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
 	}
 }
 

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -2,6 +2,12 @@
 
 This page mirrors the canonical [`CHANGELOG.md`](https://github.com/1broseidon/ketch/blob/main/CHANGELOG.md) in the repo root. Versions follow [Semantic Versioning](https://semver.org/) and match the published git tags.
 
+## Unreleased
+
+**Added**
+
+- `exa` web search backend via Exa's hosted MCP endpoint, with optional `exa_api_key` config for authenticated usage.
+
 ## v0.9.3 — 2026-05-29
 
 **Added**

--- a/site/guide/agent-integration.md
+++ b/site/guide/agent-integration.md
@@ -83,7 +83,7 @@ ketch scrape https://help.example.com/s/article/1234
   "docs_backend": "context7",
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "none",
-  "available_backends": ["brave", "ddg", "searxng"],
+  "available_backends": ["brave", "ddg", "searxng", "exa"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7", "local"]
 }

--- a/site/guide/configuration.md
+++ b/site/guide/configuration.md
@@ -25,7 +25,7 @@ The discovery payload:
   "docs_backend": "context7",
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "none",
-  "available_backends": ["brave", "ddg", "searxng"],
+  "available_backends": ["brave", "ddg", "searxng", "exa"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7", "local"]
 }
@@ -41,6 +41,7 @@ token itself is never printed. `url_rewrites` appears only when configured.
 ketch config set backend searxng
 ketch config set brave_api_key BSA...
 ketch config set searxng_url http://my-searxng:8080
+ketch config set exa_api_key exa...
 ketch config set limit 10
 ketch config set cache_ttl 4h
 ketch config set browser chrome
@@ -56,8 +57,9 @@ ketch config set github_token ghp_...
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `backend` | `brave` | Default search backend: `brave`, `ddg`, `searxng` |
+| `backend` | `brave` | Default search backend: `brave`, `ddg`, `searxng`, `exa` |
 | `brave_api_key` | — | Brave Search API key ([get one free](https://brave.com/search/api/)) |
+| `exa_api_key` | — | Optional Exa API key for authenticated hosted MCP usage |
 | `searxng_url` | `http://localhost:8081` | SearXNG instance URL |
 | `limit` | `5` | Default max results (shared by `search`, `code`, `docs`) |
 
@@ -79,7 +81,7 @@ ketch config set github_token ghp_...
 | `browser` | — | Browser for JS-rendered pages: `chrome`, `chromium`, or absolute path |
 | `url_rewrites` | — | Ordered regex rewrite rules applied before every fetch (see below) |
 
-Secrets (`brave_api_key`, `context7_api_key`, `github_token`) are stored in
+Secrets (`brave_api_key`, `exa_api_key`, `context7_api_key`, `github_token`) are stored in
 plaintext in `config.json`; protect the file accordingly.
 
 ## URL Rewrites

--- a/site/reference/backends.md
+++ b/site/reference/backends.md
@@ -4,7 +4,7 @@ ketch has three search surfaces, each with its own backends: web search (`ketch 
 
 ## Web Search Backends
 
-ketch supports three web-search backends. Set the default with `ketch config set backend <name>`.
+ketch supports four web-search backends. Set the default with `ketch config set backend <name>`.
 
 ## Brave (default)
 
@@ -47,6 +47,19 @@ ketch config set searxng_url http://localhost:8081
 ```
 
 **Recommended for:** operators running agents that search frequently, or anyone who wants full control over their search infrastructure.
+
+## Exa
+
+AI-oriented web search via Exa's hosted MCP endpoint. It works without configuration by default, with an optional Exa API key for authenticated usage.
+
+**Setup:** None for hosted MCP. Optional key:
+
+```sh
+ketch config set exa_api_key <your-key>
+ketch config set backend exa
+```
+
+**Recommended for:** agent workflows that benefit from Exa's clean result snippets and content-oriented search output.
 
 ## Code Search Backends
 

--- a/site/reference/commands.md
+++ b/site/reference/commands.md
@@ -12,7 +12,7 @@ ketch search <query> [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--backend, -b` | `brave` | Search backend: `brave`, `ddg`, `searxng` |
+| `--backend, -b` | `brave` | Search backend: `brave`, `ddg`, `searxng`, `exa` |
 | `--limit, -l` | `5` | Max number of results |
 | `--scrape` | `false` | Fetch full content from each result |
 | `--minimal` | `false` | One result per line, tab-separated |
@@ -29,6 +29,7 @@ ketch search "golang error handling"
 ketch search "rust async" --limit 10
 ketch search "python web scraping" --scrape
 ketch search "query" --backend searxng
+ketch search "query" --backend exa
 ketch search "query" --json
 ```
 


### PR DESCRIPTION
Hey, thanks for the great CLI. I thought an [Exa MCP](https://docs.exa.ai/reference/exa-mcp) search backend fit the project well and provides a nice zero-config alternative to DuckDuckGo for web search.

## Summary

Adds an `exa` backend for `ketch search` using Exa's hosted MCP endpoint.

## Changes

- Add `search.EXA` backend using Exa MCP `web_search_exa`
- Support optional `exa_api_key` config
- Add `exa` to available search backends and CLI help
- Add Exa search feature tests
- Update README, site docs, changelog, and agent docs

## Verification

- `go test ./...`
- `go build .`
- `golangci-lint run`