### PR TITLE
Add --force-browser escape hatch; finalize --raw (#11, #12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,4 @@ ketch cache                                 # show cache stats
 | --select \<css\> | scrape | — | Extract only elements matching CSS selector (skips readability) |
 | --no-llms-txt | scrape | false | Disable automatic /llms.txt detection for bare domains |
 | --concurrency | scrape | 5 | Max concurrent requests for multi-URL scraping |
+| --force-browser | scrape | false | Always render via the configured browser, skipping JS-shell auto-detection (composes with --raw/--select; errors without a browser) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `exa` web search backend via Exa's hosted MCP endpoint, with optional `exa_api_key` config for authenticated usage.
+- `ketch scrape --force-browser` — a deterministic escape hatch for JS-rendered pages whose meaningful content (e.g. pricing tables) is injected at runtime but whose static HTML still trips the "static" auto-detection (#12). Always renders via the configured browser, skipping JS-shell detection entirely; errors with `ExitPrecondition` when no browser is configured rather than silently falling back to HTTP. Composes with `--raw` (dump the rendered HTML) and `--select` (run the CSS selector against the rendered DOM), and skips the `/llms.txt` probe. A cache hit is honored only for a prior browser render (`source == browser`); HTTP/shell/markdown-only entries never satisfy a forced request. JS-shell *auto-detection* tuning is tracked separately. Documents the previously-undocumented `--raw` flag alongside it (#11).
 
 ## [0.9.3] - 2026-05-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Default output uses YAML frontmatter + markdown (cymbal style):
 | `--minimal` | search, code, docs | false | One result per line, tab-separated url/title/snippet, no frontmatter |
 | `--select <css>` | scrape | — | Extract only elements matching CSS selector (skips readability) |
 | `--no-llms-txt` | scrape | false | Disable automatic /llms.txt detection for bare domains |
+| `--raw` | scrape | false | Output raw HTML instead of markdown (skips `/llms.txt`; incompatible with `--select`/`--trim`) |
+| `--force-browser` | scrape | false | Always render via the configured browser, skipping JS-shell auto-detection (errors without a browser); composes with `--raw` and `--select` |
 
 ### Multi-URL Scraping
 ketch scrape detects input mode automatically — no flags needed:

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ ketch docs --resolve "glamour"
 | `--trim` | search, scrape | false | Strip markdown formatting, keep text |
 | `--max-chars` | search, scrape | 0 | Truncate markdown to N chars (0 = off) |
 | `--no-llms-txt` | scrape | false | Disable `/llms.txt` detection for bare domains |
+| `--force-browser` | scrape | false | Always render via the configured browser (skips JS-shell detection; composes with `--raw`/`--select`) |
 | `--concurrency` | scrape | 5 | Max concurrent requests (multi-URL scrape) |
 | `--no-cache` | scrape, crawl | false | Bypass page cache |
 | `--depth` | crawl | 3 | Max BFS depth |

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -31,6 +31,12 @@ type cacheEntry struct {
 	CachedAt int64       `json:"t"`
 	Source   string      `json:"s,omitempty"`
 	Page     scrape.Page `json:"p"`
+	// RawHTML is the post-fetch (possibly browser-rendered) HTML that produced
+	// Page. Stored as a sibling to Page — never on Page itself, which is the
+	// extracted representation shared with every JSON/crawl consumer. Persisted
+	// lazily: only --raw requests back-fill this, so the common markdown-only
+	// path pays no 20 MiB-body cost. omitempty keeps pre-raw entries decodable.
+	RawHTML string `json:"r,omitempty"`
 }
 
 // New creates a cache with the default bbolt backend.
@@ -44,6 +50,12 @@ func New(ttl time.Duration) *Cache {
 	if err != nil {
 		return nil
 	}
+	return &Cache{store: store, ttl: ttl}
+}
+
+// NewWithStore builds a cache over a caller-supplied Store. Used by tests to
+// isolate the cache (temp bbolt path) from the user's real cache dir.
+func NewWithStore(store Store, ttl time.Duration) *Cache {
 	return &Cache{store: store, ttl: ttl}
 }
 
@@ -104,6 +116,52 @@ func (c *Cache) Put(url string, page *scrape.Page, source string) {
 		CachedAt: time.Now().Unix(),
 		Source:   source,
 		Page:     *page,
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return
+	}
+	_ = c.store.Put(cacheKey(url), data)
+}
+
+// GetRaw looks up a cached entry's raw HTML by URL. Returns (rawHTML, source,
+// page). It is a hit only when the entry exists, is fresh, AND has non-empty
+// RawHTML — a markdown-only entry must not poison a --raw request (serving
+// empty HTML). On miss or empty raw, returns ("", "", nil) so the caller
+// refetches and back-fills.
+func (c *Cache) GetRaw(url string) (string, string, *scrape.Page) {
+	if c == nil {
+		return "", "", nil
+	}
+	data, err := c.store.Get(cacheKey(url))
+	if err != nil {
+		return "", "", nil
+	}
+	var e cacheEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return "", "", nil
+	}
+	if time.Since(time.Unix(e.CachedAt, 0)) > c.ttl {
+		return "", "", nil
+	}
+	if e.RawHTML == "" {
+		return "", "", nil
+	}
+	return e.RawHTML, e.Source, &e.Page
+}
+
+// PutRaw writes a page plus its raw HTML to the cache with the fetch source.
+// Used by --raw to persist both representations from a single fetch. The
+// markdown-only Put path is unchanged and keeps omitting RawHTML.
+func (c *Cache) PutRaw(url string, page *scrape.Page, source, rawHTML string) {
+	if c == nil {
+		return
+	}
+	e := cacheEntry{
+		CachedAt: time.Now().Unix(),
+		Source:   source,
+		Page:     *page,
+		RawHTML:  rawHTML,
 	}
 	data, err := json.Marshal(e)
 	if err != nil {

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -45,6 +45,7 @@ func init() {
 	scrapeCmd.Flags().String("select", "", "CSS selector to extract specific elements (skips readability)")
 	scrapeCmd.Flags().Bool("no-llms-txt", false, "disable automatic /llms.txt detection for bare domains")
 	scrapeCmd.Flags().Int("concurrency", 5, "max concurrent requests for multi-URL scraping")
+	scrapeCmd.Flags().Bool("force-browser", false, "always render via the configured browser, skipping JS-shell auto-detection")
 }
 
 func runScrape(cmd *cobra.Command, args []string) error {
@@ -55,6 +56,19 @@ func runScrape(cmd *cobra.Command, args []string) error {
 	selector, _ := cmd.Flags().GetString("select")
 	noLLMSTxt, _ := cmd.Flags().GetBool("no-llms-txt")
 	concurrency, _ := cmd.Flags().GetInt("concurrency")
+	raw, _ := cmd.Flags().GetBool("raw")
+	forceBrowser, _ := cmd.Flags().GetBool("force-browser")
+
+	// --raw is an output mode over the canonical fetch result, so it is
+	// incompatible with the extraction-oriented flags.
+	if raw {
+		if selector != "" {
+			return exitErrf(ExitValidation, "--raw cannot be combined with --select (select is extraction-oriented)")
+		}
+		if trim {
+			return exitErrf(ExitValidation, "--raw cannot be combined with --trim (trim is markdown-specific)")
+		}
+	}
 
 	urls, err := resolveURLs(args)
 	if err != nil {
@@ -67,14 +81,20 @@ func runScrape(cmd *cobra.Command, args []string) error {
 	}
 	defer scraper.Close()
 
+	// --force-browser is a hard opt-in: never silently fall back to HTTP, or it
+	// would reproduce the JS-shell confusion the flag exists to avoid.
+	if forceBrowser && !scraper.HasBrowser() {
+		return exitErrf(ExitPrecondition, "--force-browser requires a configured browser (set with: ketch config set browser chrome)")
+	}
+
 	pc := newPageCache(noCache)
 	defer pc.Close()
 
 	ctx := cmd.Context()
 	if len(urls) == 1 {
-		return scrapeSingle(ctx, scraper, pc, urls[0], asJSON, trim, maxChars, selector, noLLMSTxt)
+		return scrapeSingle(ctx, scraper, pc, urls[0], asJSON, raw, trim, maxChars, selector, noLLMSTxt, forceBrowser)
 	}
-	return scrapeMultiple(ctx, scraper, pc, urls, asJSON, trim, maxChars, selector, noLLMSTxt, concurrency)
+	return scrapeMultiple(ctx, scraper, pc, urls, asJSON, raw, trim, maxChars, selector, noLLMSTxt, concurrency, forceBrowser)
 }
 
 // resolveURLs detects the input mode and returns a list of URLs.
@@ -197,14 +217,112 @@ func cachedScrape(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url s
 	return page, nil
 }
 
-func scrapeSingle(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, rawURL string, asJSON bool, trim bool, maxChars int, selector string, noLLMSTxt bool) error {
-	// --select: direct fetch + CSS extraction, bypasses cache
-	if selector != "" {
-		return scrapeWithSelector(ctx, s, rawURL, asJSON, trim, maxChars, selector)
+// cachedScrapeRaw is the --raw path. It routes through ScrapeConditional so one
+// fetch yields Page + RawHTML + Source (the markdown path's Scrape discards
+// the body). Raw lookup is a hit only when RawHTML is non-empty — a
+// markdown-only entry does not poison a --raw request. On a raw miss against
+// an existing markdown entry, the refetch back-fills RawHTML while preserving
+// the cached Page (one fetch, both representations cached). --no-cache (pc is
+// nil) skips cache read/write and returns the fresh fetch result directly.
+func cachedScrapeRaw(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url string) (*scrape.Page, string, string, error) {
+	key := s.Rewrite(url)
+	if pc != nil {
+		if rawHTML, source, page := pc.GetRaw(key); page != nil {
+			return page, rawHTML, source, nil
+		}
 	}
 
-	// llms.txt auto-detection for bare domains
-	if !noLLMSTxt {
+	result, err := s.ScrapeConditional(ctx, url, "", "")
+	if err != nil {
+		return nil, "", "", err
+	}
+	if result.NotModified {
+		return nil, "", "", exitErrf(ExitUpstream, "unexpected 304 Not Modified without cached ETag for %s", url)
+	}
+
+	if pc != nil {
+		pc.PutRaw(key, result.Page, result.Source, result.RawHTML)
+	}
+	return result.Page, result.RawHTML, result.Source, nil
+}
+
+// cachedScrapeForce is the --force-browser markdown path. It always renders via
+// the browser, reusing a cache entry only when that entry is itself a browser
+// render (Position A: --force-browser selects the rendering pipeline, not cache
+// freshness — use --no-cache for that). HTTP/shell/markdown-only entries never
+// satisfy a forced request, which is precisely the #12 anti-poisoning guard.
+func cachedScrapeForce(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url string) (*scrape.Page, error) {
+	key := s.Rewrite(url)
+	if page, source := pc.Get(key); page != nil && source == scrape.SourceBrowser {
+		return page, nil
+	}
+	page, _, err := s.BrowserScrape(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	pc.Put(key, page, scrape.SourceBrowser)
+	return page, nil
+}
+
+// cachedScrapeRawForce is the --force-browser --raw path: render unconditionally
+// and emit the rendered HTML. A cache hit is honored only for a prior browser
+// render (GetRaw already requires non-empty RawHTML). BrowserScrape runs
+// extractor.Extract internally; the resulting markdown Page is unused here, but
+// that work is dwarfed by render cost — don't split the API to avoid it.
+func cachedScrapeRawForce(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url string) (*scrape.Page, string, string, error) {
+	key := s.Rewrite(url)
+	if pc != nil {
+		if rawHTML, source, page := pc.GetRaw(key); page != nil && source == scrape.SourceBrowser {
+			return page, rawHTML, source, nil
+		}
+	}
+	page, html, err := s.BrowserScrape(ctx, url)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if pc != nil {
+		pc.PutRaw(key, page, scrape.SourceBrowser, html)
+	}
+	return page, html, scrape.SourceBrowser, nil
+}
+
+// scrapeMarkdown picks the markdown fetch path: forced browser render or the
+// auto-detecting cachedScrape.
+func scrapeMarkdown(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url string, forceBrowser bool) (*scrape.Page, error) {
+	if forceBrowser {
+		return cachedScrapeForce(ctx, s, pc, url)
+	}
+	return cachedScrape(ctx, s, pc, url)
+}
+
+// scrapeRaw picks the --raw fetch path: forced browser render or the
+// auto-detecting cachedScrapeRaw.
+func scrapeRaw(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url string, forceBrowser bool) (*scrape.Page, string, string, error) {
+	if forceBrowser {
+		return cachedScrapeRawForce(ctx, s, pc, url)
+	}
+	return cachedScrapeRaw(ctx, s, pc, url)
+}
+
+func scrapeSingle(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, rawURL string, asJSON, raw, trim bool, maxChars int, selector string, noLLMSTxt, forceBrowser bool) error {
+	// --select: direct fetch + CSS extraction, bypasses cache and --raw.
+	if selector != "" {
+		return scrapeWithSelector(ctx, s, rawURL, asJSON, trim, maxChars, selector, forceBrowser)
+	}
+
+	// --raw bypasses the llms.txt probe and all markdown post-processing:
+	// it is an output mode over the fetched HTML, not an extraction mode.
+	if raw {
+		page, rawHTML, source, err := scrapeRaw(ctx, s, pc, rawURL, forceBrowser)
+		if err != nil {
+			return exitErrf(ExitUpstream, "scrape failed: %w", err)
+		}
+		return emitRaw(os.Stdout, page, rawHTML, source, asJSON, maxChars)
+	}
+
+	// llms.txt auto-detection for bare domains. Skipped under --force-browser:
+	// the caller explicitly wants the rendered page, not an /llms.txt shortcut.
+	if !noLLMSTxt && !forceBrowser {
 		if content, ok := fetchLLMSTxt(ctx, rawURL); ok {
 			page := &scrape.Page{URL: rawURL, Title: "llms.txt", Markdown: content}
 			page.Markdown = postProcess(page.Markdown, trim, maxChars)
@@ -216,7 +334,7 @@ func scrapeSingle(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, rawUR
 		}
 	}
 
-	page, err := cachedScrape(ctx, s, pc, rawURL)
+	page, err := scrapeMarkdown(ctx, s, pc, rawURL, forceBrowser)
 	if err != nil {
 		return exitErrf(ExitUpstream, "scrape failed: %w", err)
 	}
@@ -231,14 +349,16 @@ func scrapeSingle(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, rawUR
 	return nil
 }
 
-func scrapeMultiple(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON, trim bool, maxChars int, selector string, noLLMSTxt bool, concurrency int) error {
-	type indexedPage struct {
-		idx  int
-		page *scrape.Page
-		err  error
+func scrapeMultiple(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, urls []string, asJSON, raw, trim bool, maxChars int, selector string, noLLMSTxt bool, concurrency int, forceBrowser bool) error {
+	type indexedResult struct {
+		idx     int
+		page    *scrape.Page
+		rawHTML string
+		source  string
+		err     error
 	}
 
-	results := make([]indexedPage, len(urls))
+	results := make([]indexedResult, len(urls))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, concurrency)
 
@@ -249,13 +369,24 @@ func scrapeMultiple(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			page, err := scrapeOneURL(ctx, s, pc, rawURL, selector, noLLMSTxt)
-			results[idx] = indexedPage{idx: idx, page: page, err: err}
+			page, rawHTML, source, err := scrapeOneURL(ctx, s, pc, rawURL, raw, selector, noLLMSTxt, forceBrowser)
+			results[idx] = indexedResult{idx: idx, page: page, rawHTML: rawHTML, source: source, err: err}
 		}(i, u)
 	}
 	wg.Wait()
 
 	if asJSON {
+		if raw {
+			out := make([]rawJSON, 0, len(results))
+			for _, r := range results {
+				if r.err != nil {
+					fmt.Fprintf(os.Stderr, "warn: %v\n", r.err)
+					continue
+				}
+				out = append(out, rawResultJSON(r.page, r.rawHTML, r.source, maxChars))
+			}
+			return json.NewEncoder(os.Stdout).Encode(out)
+		}
 		pages := make([]*scrape.Page, 0, len(results))
 		for _, r := range results {
 			if r.err != nil {
@@ -273,6 +404,13 @@ func scrapeMultiple(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url
 			fmt.Fprintf(os.Stderr, "warn: %v\n", r.err)
 			continue
 		}
+		if raw {
+			if i > 0 {
+				fmt.Println()
+			}
+			_ = emitRaw(os.Stdout, r.page, r.rawHTML, r.source, false, maxChars)
+			continue
+		}
 		r.page.Markdown = postProcess(r.page.Markdown, trim, maxChars)
 		if i > 0 {
 			fmt.Println()
@@ -282,28 +420,37 @@ func scrapeMultiple(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, url
 	return nil
 }
 
-// scrapeOneURL handles a single URL within scrapeMultiple, applying selector
-// and llms.txt detection the same way scrapeSingle does.
-func scrapeOneURL(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, rawURL, selector string, noLLMSTxt bool) (*scrape.Page, error) {
+// scrapeOneURL handles a single URL within scrapeMultiple, applying selector,
+// raw, and llms.txt detection the same way scrapeSingle does.
+func scrapeOneURL(ctx context.Context, s *scrape.Scraper, pc *cache.Cache, rawURL string, raw bool, selector string, noLLMSTxt, forceBrowser bool) (*scrape.Page, string, string, error) {
 	if selector != "" {
-		return scrapeURLWithSelector(ctx, s, rawURL, selector)
+		page, err := scrapeURLWithSelector(ctx, s, rawURL, selector, forceBrowser)
+		return page, "", "", err
 	}
-	if !noLLMSTxt {
+	if raw {
+		page, rawHTML, source, err := scrapeRaw(ctx, s, pc, rawURL, forceBrowser)
+		return page, rawHTML, source, err
+	}
+	if !noLLMSTxt && !forceBrowser {
 		if content, ok := fetchLLMSTxt(ctx, rawURL); ok {
-			return &scrape.Page{URL: rawURL, Title: "llms.txt", Markdown: content}, nil
+			return &scrape.Page{URL: rawURL, Title: "llms.txt", Markdown: content}, "", "", nil
 		}
 	}
-	return cachedScrape(ctx, s, pc, rawURL)
+	page, err := scrapeMarkdown(ctx, s, pc, rawURL, forceBrowser)
+	return page, "", "", err
 }
 
 // scrapeURLWithSelector fetches a URL and extracts content matching a CSS selector.
 // Returns a Page without post-processing (caller applies trim/maxChars).
-func scrapeURLWithSelector(ctx context.Context, s *scrape.Scraper, rawURL, selector string) (*scrape.Page, error) {
-	html, err := s.Fetch(ctx, rawURL)
+func scrapeURLWithSelector(ctx context.Context, s *scrape.Scraper, rawURL, selector string, forceBrowser bool) (*scrape.Page, error) {
+	// Rewrite before fetch so --select shares the canonical URL-rewrite path
+	// with Scrape/ScrapeConditional. Previously it fetched the unrewritten
+	// URL, silently skipping configured rewrites.
+	fetchURL := s.Rewrite(rawURL)
+	html, err := fetchHTMLForSelector(ctx, s, rawURL, fetchURL, forceBrowser)
 	if err != nil {
-		return nil, exitErrf(ExitUpstream, "fetch failed: %w", err)
+		return nil, err
 	}
-	html, _ = s.MaybeBrowserFetch(ctx, rawURL, html)
 	markdown, err := extract.ExtractSelector(html, selector)
 	if err != nil {
 		return nil, exitErrf(ExitValidation, "selector extraction failed: %w", err)
@@ -312,11 +459,36 @@ func scrapeURLWithSelector(ctx context.Context, s *scrape.Scraper, rawURL, selec
 		return nil, exitErrf(ExitNotFound, "no elements matched selector %q", selector)
 	}
 	title := extract.Title(html)
-	return &scrape.Page{URL: rawURL, Title: title, Markdown: markdown}, nil
+	page := &scrape.Page{URL: rawURL, Title: title, Markdown: markdown}
+	if fetchURL != rawURL {
+		page.FetchedURL = fetchURL
+	}
+	return page, nil
 }
 
-func scrapeWithSelector(ctx context.Context, s *scrape.Scraper, rawURL string, asJSON bool, trim bool, maxChars int, selector string) error {
-	page, err := scrapeURLWithSelector(ctx, s, rawURL, selector)
+// fetchHTMLForSelector returns the HTML to run a CSS selector against. Under
+// --force-browser it renders via the browser (then selects the rendered DOM);
+// otherwise it does the plain fetch with JS-shell auto-detection. rawURL is
+// passed to BrowserScrape, which rewrites internally; fetchURL is the
+// already-rewritten URL for the plain Fetch path.
+func fetchHTMLForSelector(ctx context.Context, s *scrape.Scraper, rawURL, fetchURL string, forceBrowser bool) (string, error) {
+	if forceBrowser {
+		_, html, err := s.BrowserScrape(ctx, rawURL)
+		if err != nil {
+			return "", exitErrf(ExitUpstream, "browser fetch failed: %w", err)
+		}
+		return html, nil
+	}
+	html, err := s.Fetch(ctx, fetchURL)
+	if err != nil {
+		return "", exitErrf(ExitUpstream, "fetch failed: %w", err)
+	}
+	html, _ = s.MaybeBrowserFetch(ctx, fetchURL, html)
+	return html, nil
+}
+
+func scrapeWithSelector(ctx context.Context, s *scrape.Scraper, rawURL string, asJSON bool, trim bool, maxChars int, selector string, forceBrowser bool) error {
+	page, err := scrapeURLWithSelector(ctx, s, rawURL, selector, forceBrowser)
 	if err != nil {
 		return err
 	}
@@ -325,6 +497,46 @@ func scrapeWithSelector(ctx context.Context, s *scrape.Scraper, rawURL string, a
 		return json.NewEncoder(os.Stdout).Encode(page)
 	}
 	printPage(page)
+	return nil
+}
+
+// rawJSON is the --raw --json output shape. Plain --json must not include
+// raw_html; only the --raw path emits this.
+type rawJSON struct {
+	URL        string `json:"url"`
+	FetchedURL string `json:"fetched_url,omitempty"`
+	Title      string `json:"title"`
+	Source     string `json:"source"`
+	RawHTML    string `json:"raw_html"`
+}
+
+// rawResultJSON builds the JSON object for one --raw result, truncating the
+// HTML to maxChars Unicode code points when maxChars > 0.
+func rawResultJSON(page *scrape.Page, rawHTML, source string, maxChars int) rawJSON {
+	return rawJSON{
+		URL:        page.URL,
+		FetchedURL: page.FetchedURL,
+		Title:      page.Title,
+		Source:     source,
+		RawHTML:    truncateContent(rawHTML, maxChars),
+	}
+}
+
+// emitRaw writes a single --raw result to w. Plain output is bare HTML with
+// no --- front matter so it pipes cleanly into pup/htmlq/a file. JSON output
+// is {url, fetched_url, title, source, raw_html}.
+func emitRaw(w io.Writer, page *scrape.Page, rawHTML, source string, asJSON bool, maxChars int) error {
+	if asJSON {
+		return json.NewEncoder(w).Encode(rawResultJSON(page, rawHTML, source, maxChars))
+	}
+	if _, err := fmt.Fprint(w, truncateContent(rawHTML, maxChars)); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(rawHTML, "\n") {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cmd/scrape_force_browser_test.go
+++ b/cmd/scrape_force_browser_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1broseidon/ketch/scrape"
+)
+
+// renderedHTML is what the (fake) browser returns: it carries the pricing table
+// that JS injects at runtime. The static fetch (staticHTML) lacks it — that gap
+// is exactly issue #12. Has an id="prices" element for the --select test.
+const renderedHTML = `<!doctype html>
+<html><head><title>Pricing</title></head>
+<body><main><h1>Endpoint Pricing</h1>
+<table id="prices"><tr><td>gpt-4-turbo</td><td>$10 / $30 per 1M tokens</td></tr></table>
+</main></body></html>`
+
+// fakeBrowser is a BrowserConn that returns canned HTML and counts renders.
+type fakeBrowser struct {
+	html  string
+	calls atomic.Int32
+}
+
+func (f *fakeBrowser) Fetch(_ context.Context, _ string) (string, error) {
+	f.calls.Add(1)
+	return f.html, nil
+}
+
+func (f *fakeBrowser) Close() {}
+
+// TestForceBrowserMarkdownRendersUnconditionally — --force-browser markdown path
+// renders via the browser even though staticHTML would detect as "static".
+func TestForceBrowserMarkdownRendersUnconditionally(t *testing.T) {
+	fb := &fakeBrowser{html: renderedHTML}
+	s := scrape.NewWithBrowserConn(fb, nil)
+	pc := newTestCache(t, time.Hour)
+
+	page, err := cachedScrapeForce(context.Background(), s, pc, "https://x.test/p")
+	if err != nil {
+		t.Fatalf("cachedScrapeForce: %v", err)
+	}
+	if fb.calls.Load() != 1 {
+		t.Errorf("browser renders = %d, want 1", fb.calls.Load())
+	}
+	if !strings.Contains(page.Markdown, "gpt-4-turbo") {
+		t.Errorf("rendered markdown missing pricing content, got %q", page.Markdown)
+	}
+}
+
+// TestForceBrowserRawEmitsRenderedHTML — --raw --force-browser emits the
+// rendered HTML (with the table), labeled SourceBrowser, not the static shell.
+func TestForceBrowserRawEmitsRenderedHTML(t *testing.T) {
+	fb := &fakeBrowser{html: renderedHTML}
+	s := scrape.NewWithBrowserConn(fb, nil)
+	pc := newTestCache(t, time.Hour)
+
+	page, rawHTML, source, err := cachedScrapeRawForce(context.Background(), s, pc, "https://x.test/p")
+	if err != nil {
+		t.Fatalf("cachedScrapeRawForce: %v", err)
+	}
+	if source != scrape.SourceBrowser {
+		t.Errorf("source = %q, want %q", source, scrape.SourceBrowser)
+	}
+	if !strings.Contains(rawHTML, `id="prices"`) {
+		t.Errorf("rendered raw HTML missing the table, got %q", firstLine(rawHTML))
+	}
+	if page == nil || page.Title != "Pricing" {
+		t.Errorf("page title = %q, want Pricing", pageOrEmpty(page))
+	}
+	if fb.calls.Load() != 1 {
+		t.Errorf("browser renders = %d, want 1", fb.calls.Load())
+	}
+}
+
+// TestForceBrowserSelectAppliesToRenderedDOM — --select --force-browser runs the
+// CSS selector against the rendered DOM, so it can reach JS-injected elements.
+func TestForceBrowserSelectAppliesToRenderedDOM(t *testing.T) {
+	fb := &fakeBrowser{html: renderedHTML}
+	s := scrape.NewWithBrowserConn(fb, nil)
+
+	page, err := scrapeURLWithSelector(context.Background(), s, "https://x.test/p", "#prices", true)
+	if err != nil {
+		t.Fatalf("scrapeURLWithSelector force: %v", err)
+	}
+	if !strings.Contains(page.Markdown, "gpt-4-turbo") {
+		t.Errorf("selector on rendered DOM lost table content, got %q", page.Markdown)
+	}
+	if fb.calls.Load() != 1 {
+		t.Errorf("browser renders = %d, want 1", fb.calls.Load())
+	}
+}
+
+// TestForceBrowserWithoutBrowserIsPrecondition — --force-browser with no
+// configured browser is an ExitPrecondition error, never a silent HTTP fallback.
+func TestForceBrowserWithoutBrowserIsPrecondition(t *testing.T) {
+	prev := cfg.Browser
+	cfg.Browser = ""
+	t.Cleanup(func() { cfg.Browser = prev })
+
+	srv, _ := staticServer(t)
+	cmd := buildScrapeCmd([]string{"scrape", "--force-browser", srv.URL})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected precondition error, got nil")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *ExitError, got %T: %v", err, err)
+	}
+	if ee.Code != ExitPrecondition {
+		t.Errorf("exit code = %d, want %d", ee.Code, ExitPrecondition)
+	}
+	if !strings.Contains(err.Error(), "--force-browser requires a configured browser") {
+		t.Errorf("error %q missing guidance", err.Error())
+	}
+}
+
+// TestForceBrowserIgnoresHTTPCacheEntry — the #12 anti-poisoning guard. A
+// pre-existing SourceHTTP (markdown-only) cache entry must NOT satisfy a
+// --force-browser request; it re-renders via the browser.
+func TestForceBrowserIgnoresHTTPCacheEntry(t *testing.T) {
+	fb := &fakeBrowser{html: renderedHTML}
+	s := scrape.NewWithBrowserConn(fb, nil)
+	pc := newTestCache(t, time.Hour)
+
+	// Prime a stale SourceHTTP entry (the unrendered static page).
+	pc.Put("https://x.test/p", &scrape.Page{URL: "https://x.test/p", Title: "Pricing", Markdown: "stale http content"}, scrape.SourceHTTP)
+
+	page, err := cachedScrapeForce(context.Background(), s, pc, "https://x.test/p")
+	if err != nil {
+		t.Fatalf("cachedScrapeForce: %v", err)
+	}
+	if fb.calls.Load() != 1 {
+		t.Errorf("browser renders = %d, want 1 (HTTP entry must not satisfy force)", fb.calls.Load())
+	}
+	if strings.Contains(page.Markdown, "stale http content") {
+		t.Errorf("force-browser served the stale SourceHTTP entry: %q", page.Markdown)
+	}
+	if !strings.Contains(page.Markdown, "gpt-4-turbo") {
+		t.Errorf("expected freshly rendered content, got %q", page.Markdown)
+	}
+}
+
+// TestForceBrowserReusesBrowserCacheEntry — Position A: a forced result cached
+// as SourceBrowser is re-read on a subsequent forced run without re-rendering.
+func TestForceBrowserReusesBrowserCacheEntry(t *testing.T) {
+	fb := &fakeBrowser{html: renderedHTML}
+	s := scrape.NewWithBrowserConn(fb, nil)
+	pc := newTestCache(t, time.Hour)
+
+	if _, err := cachedScrapeForce(context.Background(), s, pc, "https://x.test/p"); err != nil {
+		t.Fatalf("first cachedScrapeForce: %v", err)
+	}
+	if fb.calls.Load() != 1 {
+		t.Fatalf("after first call renders = %d, want 1", fb.calls.Load())
+	}
+
+	if _, err := cachedScrapeForce(context.Background(), s, pc, "https://x.test/p"); err != nil {
+		t.Fatalf("second cachedScrapeForce: %v", err)
+	}
+	if fb.calls.Load() != 1 {
+		t.Errorf("second call re-rendered (renders = %d); SourceBrowser entry should be reused", fb.calls.Load())
+	}
+}
+
+// TestForceBrowserSkipsLLMSTxtProbe — under --force-browser the bare-domain
+// /llms.txt probe is skipped; the browser render is authoritative.
+func TestForceBrowserSkipsLLMSTxtProbe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/llms.txt" {
+			t.Errorf("--force-browser must skip the llms.txt probe, but it was requested")
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(staticHTML))
+	}))
+	t.Cleanup(srv.Close)
+
+	fb := &fakeBrowser{html: renderedHTML}
+	s := scrape.NewWithBrowserConn(fb, nil)
+	pc := newTestCache(t, time.Hour)
+
+	page, _, _, err := scrapeOneURL(context.Background(), s, pc, srv.URL+"/", false, "", false, true)
+	if err != nil {
+		t.Fatalf("scrapeOneURL force: %v", err)
+	}
+	if !strings.Contains(page.Markdown, "gpt-4-turbo") {
+		t.Errorf("expected rendered content, got %q", page.Markdown)
+	}
+	if fb.calls.Load() != 1 {
+		t.Errorf("browser renders = %d, want 1", fb.calls.Load())
+	}
+}

--- a/cmd/scrape_raw_test.go
+++ b/cmd/scrape_raw_test.go
@@ -1,0 +1,361 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1broseidon/ketch/cache"
+	"github.com/1broseidon/ketch/scrape"
+	"github.com/1broseidon/ketch/urlrewrite"
+	"github.com/spf13/cobra"
+)
+
+// staticHTML is a non-JS-shell page: detect returns "static", so the browser
+// is never invoked and Source is SourceHTTP.
+const staticHTML = `<!doctype html>
+<html><head><title>Pricing</title></head>
+<body><main><h1>Endpoint Pricing</h1><p>OpenAI gpt-4-turbo $10/$30 per 1M tokens</p></main></body></html>`
+
+// newTestCache returns a cache backed by an isolated temp bbolt file so tests
+// never touch the user's real cache dir.
+func newTestCache(t *testing.T, ttl time.Duration) *cache.Cache {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := cache.NewBBoltStore(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open test cache: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return cache.NewWithStore(store, ttl)
+}
+
+// staticServer serves staticHTML from every path and counts fetches.
+func staticServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(staticHTML))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// TestRawEmitBareHTMLNoFrontMatter — the #11 regression: --raw emits HTML,
+// not markdown, and plain output has no ---/url:/title: header.
+func TestRawEmitBareHTMLNoFrontMatter(t *testing.T) {
+	page := &scrape.Page{URL: "https://x.test/p", Title: "Pricing"}
+	var buf bytes.Buffer
+	if err := emitRaw(&buf, page, staticHTML, scrape.SourceHTTP, false, 0); err != nil {
+		t.Fatalf("emitRaw: %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(strings.TrimSpace(out), "<!doctype html>") {
+		t.Errorf("--raw plain output must be HTML, got: %q", firstLine(out))
+	}
+	if strings.Contains(out, "---\nurl:") {
+		t.Errorf("--raw plain output must not include the --- front-matter header, got: %q", out)
+	}
+	if !strings.Contains(out, "<title>Pricing</title>") {
+		t.Errorf("--raw plain output lost the <title>, got: %q", out)
+	}
+}
+
+// TestRawJSONIncludesSourceAndRawHTML — --raw --json shape: {url, fetched_url,
+// title, source, raw_html}.
+func TestRawJSONIncludesSourceAndRawHTML(t *testing.T) {
+	page := &scrape.Page{URL: "https://x.test/p", FetchedURL: "https://x.test/p", Title: "Pricing"}
+	var buf bytes.Buffer
+	if err := emitRaw(&buf, page, staticHTML, scrape.SourceHTTP, true, 0); err != nil {
+		t.Fatalf("emitRaw: %v", err)
+	}
+	var got rawJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body %q)", err, buf.String())
+	}
+	if got.Source != scrape.SourceHTTP {
+		t.Errorf("source = %q, want %q", got.Source, scrape.SourceHTTP)
+	}
+	if got.RawHTML != staticHTML {
+		t.Errorf("raw_html mismatch")
+	}
+	if got.Title != "Pricing" {
+		t.Errorf("title = %q", got.Title)
+	}
+}
+
+// TestCachedScrapeRawReturnsHTMLAndHTTPSource — one fetch via the canonical
+// ScrapeConditional path yields HTML labeled SourceHTTP; a static page does
+// NOT spin up a browser.
+func TestCachedScrapeRawReturnsHTMLAndHTTPSource(t *testing.T) {
+	srv, hits := staticServer(t)
+	s := scrape.NewWithRewriter("", nil)
+	pc := newTestCache(t, time.Hour)
+
+	page, rawHTML, source, err := cachedScrapeRaw(context.Background(), s, pc, srv.URL+"/pricing")
+	if err != nil {
+		t.Fatalf("cachedScrapeRaw: %v", err)
+	}
+	if source != scrape.SourceHTTP {
+		t.Errorf("static page source = %q, want %q (browser must not spin up)", source, scrape.SourceHTTP)
+	}
+	if !strings.Contains(rawHTML, "<title>Pricing</title>") {
+		t.Errorf("rawHTML missing <title>, got: %q", firstLine(rawHTML))
+	}
+	if page == nil || page.Title != "Pricing" {
+		t.Errorf("page title = %q, want Pricing", pageOrEmpty(page))
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected exactly 1 fetch, got %d", hits.Load())
+	}
+}
+
+// TestCachedScrapeRawNoCacheBypassesCache — --no-cache (pc nil) returns the
+// fresh fetch result without reading or writing the cache.
+func TestCachedScrapeRawNoCacheBypassesCache(t *testing.T) {
+	srv, hits := staticServer(t)
+	s := scrape.NewWithRewriter("", nil)
+
+	_, rawHTML, source, err := cachedScrapeRaw(context.Background(), s, nil, srv.URL+"/p")
+	if err != nil {
+		t.Fatalf("cachedScrapeRaw nil cache: %v", err)
+	}
+	if source != scrape.SourceHTTP {
+		t.Errorf("source = %q, want %q", source, scrape.SourceHTTP)
+	}
+	if !strings.Contains(rawHTML, "<title>") {
+		t.Errorf("nil-cache rawHTML missing <title>")
+	}
+	if hits.Load() != 1 {
+		t.Errorf("expected 1 fetch, got %d", hits.Load())
+	}
+}
+
+// TestCachedScrapeRawMarkdownOnlyEntryDoesNotPoisonRaw — the critical
+// correctness test. A markdown-only cached entry (via cachedScrape/Put, which
+// omits RawHTML) must NOT satisfy a later --raw request. GetRaw must miss,
+// trigger a refetch, and back-fill RawHTML while preserving the existing Page.
+func TestCachedScrapeRawMarkdownOnlyEntryDoesNotPoisonRaw(t *testing.T) {
+	srv, hits := staticServer(t)
+	s := scrape.NewWithRewriter("", nil)
+	pc := newTestCache(t, time.Hour)
+
+	// 1. Prime a markdown-only entry via the markdown path.
+	if _, err := cachedScrape(context.Background(), s, pc, srv.URL+"/p"); err != nil {
+		t.Fatalf("prime cachedScrape: %v", err)
+	}
+	primeHits := hits.Load()
+
+	// 2. GetRaw must miss on a markdown-only entry (RawHTML empty).
+	if raw, _, _ := pc.GetRaw(srv.URL + "/p"); raw != "" {
+		t.Fatalf("markdown-only entry must not serve raw HTML, got %q", raw)
+	}
+
+	// 3. --raw must refetch and back-fill, NOT serve empty HTML.
+	page, rawHTML, source, err := cachedScrapeRaw(context.Background(), s, pc, srv.URL+"/p")
+	if err != nil {
+		t.Fatalf("cachedScrapeRaw after markdown prime: %v", err)
+	}
+	if rawHTML == "" {
+		t.Fatalf("rawHTML empty — markdown-only entry poisoned the --raw request")
+	}
+	if source != scrape.SourceHTTP {
+		t.Errorf("source = %q, want %q", source, scrape.SourceHTTP)
+	}
+	if page == nil || page.Title != "Pricing" {
+		t.Errorf("back-filled page title = %q, want Pricing", pageOrEmpty(page))
+	}
+	if hits.Load() != primeHits+1 {
+		t.Errorf("expected a refetch (%d+1), got %d", primeHits, hits.Load())
+	}
+
+	// 4. The refetched entry now round-trips: a second --raw is served from
+	// cache without a further fetch.
+	secondBefore := hits.Load()
+	if _, raw2, _, err := cachedScrapeRaw(context.Background(), s, pc, srv.URL+"/p"); err != nil {
+		t.Fatalf("second cachedScrapeRaw: %v", err)
+	} else if raw2 == "" {
+		t.Fatalf("second --raw served empty HTML — back-fill did not persist")
+	}
+	if hits.Load() != secondBefore {
+		t.Errorf("second --raw should hit the raw cache, expected %d fetches got %d", secondBefore, hits.Load())
+	}
+}
+
+// TestCachedScrapeRawOldEntryWithoutRawFieldDecodes — an entry written before
+// RawHTML existed (no `r` field) remains readable via the markdown Get path,
+// and GetRaw treats it as a miss rather than erroring.
+func TestCachedScrapeRawOldEntryWithoutRawFieldDecodes(t *testing.T) {
+	srv, _ := staticServer(t)
+	pc := newTestCache(t, time.Hour)
+
+	// Simulate a pre-raw entry: Put writes markdown-only with no RawHTML.
+	page, _, err := scrape.New().Scrape(context.Background(), srv.URL+"/p")
+	if err != nil {
+		t.Fatalf("scrape: %v", err)
+	}
+	pc.Put(srv.URL+"/p", page, scrape.SourceHTTP)
+
+	// Markdown read still works.
+	if got, _ := pc.Get(srv.URL + "/p"); got == nil {
+		t.Fatalf("markdown Get returned nil on legacy entry")
+	}
+	// Raw read is a clean miss, not an error/panic.
+	if raw, _, _ := pc.GetRaw(srv.URL + "/p"); raw != "" {
+		t.Errorf("legacy entry GetRaw should miss, got %q", raw)
+	}
+}
+
+// TestRawValidationRejectsSelectAndTrim — --raw combined with --select or
+// --trim is a validation error.
+func TestRawValidationRejectsSelectAndTrim(t *testing.T) {
+	cases := []struct {
+		name    string
+		flags   []string
+		wantSub string
+	}{
+		{"select", []string{"--raw", "--select", "main"}, "--raw cannot be combined with --select"},
+		{"trim", []string{"--raw", "--trim"}, "--raw cannot be combined with --trim"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv, _ := staticServer(t)
+			args := append([]string{"scrape", srv.URL}, c.flags...)
+			cmd := buildScrapeCmd(args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			var ee *ExitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("expected *ExitError, got %T: %v", err, err)
+			}
+			if ee.Code != ExitValidation {
+				t.Errorf("exit code = %d, want %d", ee.Code, ExitValidation)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error %q does not mention %q", err.Error(), c.wantSub)
+			}
+		})
+	}
+}
+
+// TestRawSkipsLLMSTxtProbe — --raw must not trigger the llms.txt probe. We
+// assert via fetch count on a bare-domain-style server: only the page fetch
+// should occur, never /llms.txt.
+func TestRawSkipsLLMSTxtProbe(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.URL.Path == "/llms.txt" {
+			t.Errorf("--raw must skip the llms.txt probe, but it was requested")
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(staticHTML))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd := buildScrapeCmd([]string{"scrape", "--raw", "--no-cache", srv.URL + "/"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if hits.Load() == 0 {
+		t.Errorf("expected at least the page fetch, got 0")
+	}
+}
+
+// TestRawSelectAppliesRewrite — regression: --select must Rewrite before
+// Fetch. A rewrite rule maps /src -> /dst; --select on the /src URL must hit
+// the /dst server path and populate FetchedURL.
+func TestRawSelectAppliesRewrite(t *testing.T) {
+	var gotPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<!doctype html><html><body><main id="x">picked</main></body></html>`))
+	}))
+	t.Cleanup(srv.Close)
+
+	rw, err := urlrewrite.NewRewriter([]urlrewrite.Rule{{
+		Match:   `^` + regexp.QuoteMeta(srv.URL) + `/src$`,
+		Replace: srv.URL + "/dst",
+	}})
+	if err != nil {
+		t.Fatalf("rewriter: %v", err)
+	}
+	s := scrape.NewWithRewriter("", rw)
+
+	page, err := scrapeURLWithSelector(context.Background(), s, srv.URL+"/src", "#x", false)
+	if err != nil {
+		t.Fatalf("scrapeURLWithSelector: %v", err)
+	}
+	if p := gotPath.Load(); p != "/dst" {
+		t.Errorf("--select fetched path %v, want /dst (rewrite not applied)", p)
+	}
+	if page.FetchedURL != srv.URL+"/dst" {
+		t.Errorf("FetchedURL = %q, want %s/dst", page.FetchedURL, srv.URL)
+	}
+	if !strings.Contains(page.Markdown, "picked") {
+		t.Errorf("selector extraction lost content, got %q", page.Markdown)
+	}
+}
+
+// TestRawJSONPlainJSONExcludesRawHTML — plain --json (non-raw) must NOT
+// include raw_html. We verify by encoding a Page directly through the
+// markdown JSON path and asserting no raw_html field appears.
+func TestRawJSONPlainJSONExcludesRawHTML(t *testing.T) {
+	page := &scrape.Page{URL: "https://x.test/p", Title: "T", Markdown: "body"}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(page); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if strings.Contains(buf.String(), "raw_html") {
+		t.Errorf("plain --json must not include raw_html, got %q", buf.String())
+	}
+}
+
+// buildScrapeCmd constructs an isolated cobra command tree for one scrape
+// invocation, with --json available on the root and scrape flags registered.
+// It does NOT touch package globals so parallel tests are safe.
+func buildScrapeCmd(args []string) *cobraCommandShim {
+	root := &cobra.Command{Use: "ketch", SilenceUsage: true}
+	root.PersistentFlags().Bool("json", false, "output as JSON")
+	scrapeCmd := &cobra.Command{
+		Use:   "scrape",
+		Short: "Scrape URLs and extract clean markdown",
+		RunE:  runScrape,
+	}
+	scrapeCmd.Flags().Bool("raw", false, "output raw HTML instead of markdown")
+	scrapeCmd.Flags().Bool("no-cache", false, "bypass the page cache")
+	scrapeCmd.Flags().Int("max-chars", 0, "truncate output to N chars")
+	scrapeCmd.Flags().Bool("trim", false, "strip markdown formatting")
+	scrapeCmd.Flags().String("select", "", "CSS selector")
+	scrapeCmd.Flags().Bool("no-llms-txt", false, "disable llms.txt detection")
+	scrapeCmd.Flags().Int("concurrency", 5, "max concurrent requests")
+	scrapeCmd.Flags().Bool("force-browser", false, "force browser render")
+	root.AddCommand(scrapeCmd)
+	root.SetArgs(args)
+	return &cobraCommandShim{root: root}
+}
+
+type cobraCommandShim struct{ root *cobra.Command }
+
+func (s *cobraCommandShim) Execute() error { return s.root.Execute() }
+
+func pageOrEmpty(p *scrape.Page) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return p.Title
+}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -93,6 +93,16 @@ func New() *Scraper { return NewWithRewriter("", nil) }
 // NewWithBrowser creates a Scraper with browser fallback for JS-rendered pages.
 func NewWithBrowser(browserBin string) *Scraper { return NewWithRewriter(browserBin, nil) }
 
+// NewWithBrowserConn creates a Scraper backed by a pre-supplied BrowserConn,
+// bypassing binary resolution. HasBrowser reports true and getBrowser returns
+// conn directly. Used to drive browser code paths (e.g. --force-browser)
+// without a real Chrome install.
+func NewWithBrowserConn(conn BrowserConn, rw *urlrewrite.Rewriter) *Scraper {
+	s := NewWithRewriter("chrome", rw)
+	s.browser = conn
+	return s
+}
+
 // HasBrowser reports whether this scraper has browser fallback configured.
 func (s *Scraper) HasBrowser() bool {
 	return s.browserBin != ""

--- a/site/reference/commands.md
+++ b/site/reference/commands.md
@@ -108,12 +108,13 @@ Explicit args take priority over stdin, so `ketch scrape url < file` uses the UR
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--raw` | `false` | Output raw HTML instead of markdown |
+| `--raw` | `false` | Output raw HTML instead of markdown. Renders via the canonical fetch path (browser only if the page already needed it), is cached lazily, skips `/llms.txt`, and cannot be combined with `--select` or `--trim` |
 | `--select` | — | CSS selector to extract (skips readability) |
 | `--trim` | `false` | Strip markdown formatting, keep text |
 | `--max-chars` | `0` | Truncate markdown to N chars (0 = off) |
 | `--concurrency` | `5` | Max concurrent requests (multi-URL) |
 | `--no-llms-txt` | `false` | Disable `/llms.txt` detection for bare domains |
+| `--force-browser` | `false` | Always render via the configured browser, skipping JS-shell auto-detection. Errors if no browser is configured. Composes with `--raw` (dump rendered HTML) and `--select` (run the selector against the rendered DOM); skips `/llms.txt` |
 | `--no-cache` | `false` | Bypass the page cache |
 
 If a browser is configured and the page is detected as JS-rendered, ketch automatically re-fetches via headless Chrome.


### PR DESCRIPTION
## Summary

Single PR covering both open scrape issues.

- **#12 (JS-rendered page detection fails):** adds `ketch scrape --force-browser`, a deterministic opt-in that always renders via the configured browser, skipping JS-shell auto-detection. This is the fix for pages like bitdeer.ai whose pricing table is JS-injected but whose static HTML still crosses the "static" threshold, so the browser was never invoked.
- **#11 (`--raw` has no effect):** lands the previously-uncommitted `--raw` output mode (raw HTML instead of markdown), with lazy `RawHTML` cache back-fill and markdown-only anti-poisoning.

## `--force-browser` behavior

- Errors with `ExitPrecondition` when no browser is configured — never a silent HTTP fallback.
- Composes with `--raw` (dump rendered HTML) and `--select` (run the selector against the rendered DOM); skips the `/llms.txt` probe.
- **Cache (Position A):** forced results write `SourceBrowser`; a cache hit is honored **only** when `source == SourceBrowser`. HTTP/shell/markdown-only entries never satisfy a forced request (the #12 anti-poison guard). Use `--no-cache` for freshness.
- Reuses `scrape.BrowserScrape` — no new scraper API. Adds `NewWithBrowserConn` as a test seam.

## Out of scope

JS-shell **auto-detection** tuning (SPA markers / thresholds / two-phase) is deferred to a separate fixture-backed PR, so #12's override ships now without over-promising.

## Testing

- 7 new `--force-browser` unit tests (fake `BrowserConn`) + existing `--raw` suite — all green.
- `go test ./...` pass, `golangci-lint run` 0 issues (gocyclo under 15).
- **Live smoke test against bitdeer.ai with real Chrome — all 8 cases pass:**
  - auto-detect misses pricing (repro of #12); `--force-browser` captures it
  - `--raw --force-browser` returns 140 KB rendered HTML with `<td>$…</td>` cells
  - `--raw --force-browser --json` → `source: "browser"`, `raw_html` present
  - `--select table --force-browser` extracts tables from the rendered DOM
  - no-browser → exit 5, clear message, no stdout
  - cache reuse: run 1 = 6.2s render, run 2 = 0.00s (SourceBrowser reused)
  - anti-poison: cached SourceHTTP shell (0 prices) does not satisfy force (108 prices)

Closes #11
Closes #12