### PR TITLE
fix: render HTML tables as proper GFM pipe tables

### DIFF
--- a/extract/extract.go
+++ b/extract/extract.go
@@ -2,8 +2,14 @@ package extract
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	stdhtml "html"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/PuerkitoBio/goquery"
 
@@ -26,6 +32,13 @@ var markdownConverter = converter.NewConverter(
 		),
 	),
 )
+
+var markdownLinkRE = regexp.MustCompile(`!?\[([^\]]*)\]\([^)]*\)`)
+
+type tableCandidate struct {
+	fingerprint string
+	html        string
+}
 
 // Result holds extracted content from a page.
 type Result struct {
@@ -50,6 +63,14 @@ func (e *Extractor) Extract(pageURL, html string) (*Result, error) {
 		return nil, err
 	}
 
+	rawDoc, rawDocErr := goquery.NewDocumentFromReader(strings.NewReader(html))
+	var tableCandidates []tableCandidate
+	var rawTitle string
+	if rawDocErr == nil {
+		tableCandidates = collectDataTables(rawDoc)
+		rawTitle = titleFromDocument(rawDoc)
+	}
+
 	// Try readability first — clean article extraction
 	parser := readability.NewParser()
 	article, err := parser.Parse(strings.NewReader(html), u)
@@ -59,14 +80,7 @@ func (e *Extractor) Extract(pageURL, html string) (*Result, error) {
 			markdown, convErr := markdownConverter.ConvertString(buf.String())
 			markdown = strings.TrimSpace(markdown)
 			if convErr == nil && markdown != "" {
-				if hasHTMLTable(html) && !hasMarkdownPipeTable(markdown) {
-					if raw, rawErr := extractRaw(html); rawErr == nil && hasMarkdownPipeTable(raw.Markdown) {
-						if title := article.Title(); title != "" {
-							raw.Title = title
-						}
-						return raw, nil
-					}
-				}
+				markdown = reinjectLostTables(markdown, tableCandidates)
 				return &Result{
 					Title:    article.Title(),
 					Markdown: markdown,
@@ -76,14 +90,19 @@ func (e *Extractor) Extract(pageURL, html string) (*Result, error) {
 	}
 
 	// Fallback: convert full HTML to markdown directly
-	return extractRaw(html)
+	if rawTitle == "" {
+		return extractRaw(html)
+	}
+	return extractRawWithTitle(html, rawTitle)
 }
 
 // extractRaw converts the full HTML to markdown without readability.
 // Noisier output (includes nav, footer, etc.) but never fails on valid HTML.
 func extractRaw(html string) (*Result, error) {
-	title := Title(html)
+	return extractRawWithTitle(html, Title(html))
+}
 
+func extractRawWithTitle(html, title string) (*Result, error) {
 	markdown, err := markdownConverter.ConvertString(html)
 	if err != nil {
 		return nil, err
@@ -100,18 +119,286 @@ func extractRaw(html string) (*Result, error) {
 	}, nil
 }
 
-func hasHTMLTable(html string) bool {
-	return strings.Contains(strings.ToLower(html), "<table")
+func reinjectLostTables(markdown string, candidates []tableCandidate) string {
+	if len(candidates) == 0 {
+		return markdown
+	}
+
+	surviving := markdownTableFingerprints(markdown)
+	additions := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if count := surviving[candidate.fingerprint]; count > 0 {
+			surviving[candidate.fingerprint] = count - 1
+			continue
+		}
+
+		tableMarkdown, err := markdownConverter.ConvertString(candidate.html)
+		if err != nil {
+			continue
+		}
+		tableMarkdown = strings.TrimSpace(tableMarkdown)
+		if tableMarkdown == "" {
+			continue
+		}
+		additions = append(additions, tableMarkdown)
+	}
+
+	if len(additions) == 0 {
+		return markdown
+	}
+
+	parts := append([]string{strings.TrimSpace(markdown)}, additions...)
+	return strings.Join(parts, "\n\n")
 }
 
-func hasMarkdownPipeTable(markdown string) bool {
-	for _, line := range strings.Split(markdown, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "|") && strings.Contains(line, "---") {
+func collectDataTables(doc *goquery.Document) []tableCandidate {
+	var candidates []tableCandidate
+	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
+		if isLayoutTable(table) || !isDataTable(table) {
+			return
+		}
+
+		fingerprint := htmlTableFingerprint(table)
+		if fingerprint == "" {
+			return
+		}
+
+		tableHTML, err := goquery.OuterHtml(table)
+		if err != nil || strings.TrimSpace(tableHTML) == "" {
+			return
+		}
+
+		candidates = append(candidates, tableCandidate{
+			fingerprint: fingerprint,
+			html:        tableHTML,
+		})
+	})
+	return candidates
+}
+
+func isDataTable(table *goquery.Selection) bool {
+	rows, maxColumns, hasTheadTH := tableMetrics(table)
+	return rows >= 10 || maxColumns > 4 || hasTheadTH
+}
+
+func tableMetrics(table *goquery.Selection) (rows, maxColumns int, hasTheadTH bool) {
+	tableNode := table.Get(0)
+	if tableNode == nil {
+		return 0, 0, false
+	}
+
+	table.Find("tr").Each(func(_ int, row *goquery.Selection) {
+		if closestTableNode(row) != tableNode {
+			return
+		}
+		rows++
+
+		columns := 0
+		row.Find("th,td").Each(func(_ int, cell *goquery.Selection) {
+			if closestTableNode(cell) != tableNode {
+				return
+			}
+			columns += tableCellColspan(cell)
+		})
+		if columns > maxColumns {
+			maxColumns = columns
+		}
+	})
+
+	table.Find("thead th").EachWithBreak(func(_ int, cell *goquery.Selection) bool {
+		if closestTableNode(cell) == tableNode {
+			hasTheadTH = true
+			return false
+		}
+		return true
+	})
+
+	return rows, maxColumns, hasTheadTH
+}
+
+func tableCellColspan(cell *goquery.Selection) int {
+	value, ok := cell.Attr("colspan")
+	if !ok {
+		return 1
+	}
+	span, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || span < 1 {
+		return 1
+	}
+	return span
+}
+
+func closestTableNode(selection *goquery.Selection) interface{} {
+	closest := selection.ParentsFiltered("table").First()
+	if closest.Length() == 0 {
+		return nil
+	}
+	return closest.Get(0)
+}
+
+func isLayoutTable(table *goquery.Selection) bool {
+	return hasLayoutMarker(table)
+}
+
+func hasLayoutMarker(selection *goquery.Selection) bool {
+	if role, ok := selection.Attr("role"); ok && strings.EqualFold(strings.TrimSpace(role), "presentation") {
+		return true
+	}
+	class, _ := selection.Attr("class")
+	return hasLayoutClass(class)
+}
+
+func hasLayoutClass(class string) bool {
+	class = strings.ToLower(class)
+	for _, marker := range []string{"navbox", "sidebar", "toc", "ambox"} {
+		if strings.Contains(class, marker) {
 			return true
 		}
 	}
 	return false
+}
+
+func htmlTableFingerprint(table *goquery.Selection) string {
+	tableNode := table.Get(0)
+	if tableNode == nil {
+		return ""
+	}
+
+	var cells []string
+	table.Find("th,td").Each(func(_ int, cell *goquery.Selection) {
+		if closestTableNode(cell) != tableNode {
+			return
+		}
+		cells = append(cells, cell.Text())
+	})
+	return fingerprintCells(cells)
+}
+
+func markdownTableFingerprints(markdown string) map[string]int {
+	fingerprints := make(map[string]int)
+	lines := strings.Split(markdown, "\n")
+	for i := 1; i < len(lines); i++ {
+		if !isMarkdownTableSeparator(lines[i]) || !isMarkdownTableRow(lines[i-1]) {
+			continue
+		}
+
+		cells := splitMarkdownTableRow(lines[i-1])
+		j := i + 1
+		for ; j < len(lines) && isMarkdownTableRow(lines[j]); j++ {
+			cells = append(cells, splitMarkdownTableRow(lines[j])...)
+		}
+
+		fingerprint := fingerprintCells(cells)
+		if fingerprint != "" {
+			fingerprints[fingerprint]++
+		}
+		i = j - 1
+	}
+	return fingerprints
+}
+
+func isMarkdownTableRow(line string) bool {
+	return len(splitMarkdownTableRow(line)) > 1
+}
+
+func isMarkdownTableSeparator(line string) bool {
+	cells := splitMarkdownTableRow(line)
+	if len(cells) < 2 {
+		return false
+	}
+	for _, cell := range cells {
+		cell = strings.TrimSpace(cell)
+		if cell == "" || strings.Count(cell, "-") < 3 {
+			return false
+		}
+		if strings.Trim(cell, ":- ") != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func splitMarkdownTableRow(line string) []string {
+	line = strings.TrimSpace(line)
+	if !strings.Contains(line, "|") {
+		return nil
+	}
+	line = strings.TrimPrefix(line, "|")
+	if strings.HasSuffix(line, "|") && !strings.HasSuffix(line, `\|`) {
+		line = line[:len(line)-1]
+	}
+
+	var cells []string
+	var cell strings.Builder
+	escaped := false
+	for _, r := range line {
+		if escaped {
+			cell.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if r == '|' {
+			cells = append(cells, cell.String())
+			cell.Reset()
+			continue
+		}
+		cell.WriteRune(r)
+	}
+	if escaped {
+		cell.WriteRune('\\')
+	}
+	cells = append(cells, cell.String())
+	return cells
+}
+
+func fingerprintCells(cells []string) string {
+	var normalized strings.Builder
+	for _, cell := range cells {
+		text := normalizeFingerprintText(cell)
+		if text == "" {
+			continue
+		}
+		if normalized.Len() > 0 {
+			normalized.WriteByte('\x1f')
+		}
+		normalized.WriteString(text)
+	}
+	if normalized.Len() == 0 {
+		return ""
+	}
+
+	sum := sha256.Sum256([]byte(normalized.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizeFingerprintText(text string) string {
+	text = markdownLinkRE.ReplaceAllString(text, "$1")
+	text = stdhtml.UnescapeString(text)
+	text = strings.ToLower(text)
+
+	var normalized strings.Builder
+	previousSpace := true
+	for _, r := range text {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			normalized.WriteRune(r)
+			previousSpace = false
+		case unicode.IsSpace(r):
+			if !previousSpace {
+				normalized.WriteByte(' ')
+				previousSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(normalized.String())
+}
+
+func titleFromDocument(doc *goquery.Document) string {
+	return strings.TrimSpace(doc.Find("title").First().Text())
 }
 
 // ExtractSelector runs a CSS selector against raw HTML and returns the

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -8,7 +8,23 @@ import (
 	"github.com/PuerkitoBio/goquery"
 
 	readability "codeberg.org/readeck/go-readability/v2"
-	md "github.com/JohannesKaufmann/html-to-markdown/v2"
+	"github.com/JohannesKaufmann/html-to-markdown/v2/converter"
+	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/base"
+	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/commonmark"
+	"github.com/JohannesKaufmann/html-to-markdown/v2/plugin/table"
+)
+
+var markdownConverter = converter.NewConverter(
+	converter.WithPlugins(
+		base.NewBasePlugin(),
+		commonmark.NewCommonmarkPlugin(),
+		table.NewTablePlugin(
+			table.WithHeaderPromotion(true),
+			table.WithSkipEmptyRows(true),
+			table.WithNewlineBehavior(table.NewlineBehaviorPreserve),
+			table.WithCellPaddingBehavior(table.CellPaddingBehaviorMinimal),
+		),
+	),
 )
 
 // Result holds extracted content from a page.
@@ -40,11 +56,20 @@ func (e *Extractor) Extract(pageURL, html string) (*Result, error) {
 	if err == nil {
 		var buf bytes.Buffer
 		if renderErr := article.RenderHTML(&buf); renderErr == nil {
-			markdown, convErr := md.ConvertString(buf.String())
-			if convErr == nil && strings.TrimSpace(markdown) != "" {
+			markdown, convErr := markdownConverter.ConvertString(buf.String())
+			markdown = strings.TrimSpace(markdown)
+			if convErr == nil && markdown != "" {
+				if hasHTMLTable(html) && !hasMarkdownPipeTable(markdown) {
+					if raw, rawErr := extractRaw(html); rawErr == nil && hasMarkdownPipeTable(raw.Markdown) {
+						if title := article.Title(); title != "" {
+							raw.Title = title
+						}
+						return raw, nil
+					}
+				}
 				return &Result{
 					Title:    article.Title(),
-					Markdown: strings.TrimSpace(markdown),
+					Markdown: markdown,
 				}, nil
 			}
 		}
@@ -59,7 +84,7 @@ func (e *Extractor) Extract(pageURL, html string) (*Result, error) {
 func extractRaw(html string) (*Result, error) {
 	title := Title(html)
 
-	markdown, err := md.ConvertString(html)
+	markdown, err := markdownConverter.ConvertString(html)
 	if err != nil {
 		return nil, err
 	}
@@ -73,6 +98,20 @@ func extractRaw(html string) (*Result, error) {
 		Title:    title,
 		Markdown: markdown,
 	}, nil
+}
+
+func hasHTMLTable(html string) bool {
+	return strings.Contains(strings.ToLower(html), "<table")
+}
+
+func hasMarkdownPipeTable(markdown string) bool {
+	for _, line := range strings.Split(markdown, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "|") && strings.Contains(line, "---") {
+			return true
+		}
+	}
+	return false
 }
 
 // ExtractSelector runs a CSS selector against raw HTML and returns the
@@ -107,7 +146,7 @@ func ExtractSelector(rawHTML, selector string) (string, error) {
 	}
 
 	html := strings.Join(parts, "\n\n")
-	markdown, err := md.ConvertString(html)
+	markdown, err := markdownConverter.ConvertString(html)
 	if err != nil {
 		return "", err
 	}

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -1,0 +1,111 @@
+package extract
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractRendersHTMLTableAsPipeTable(t *testing.T) {
+	t.Parallel()
+
+	html := `<!doctype html>
+<html>
+<head><title>Pricing</title></head>
+<body>
+	<article>
+		<h1>Pricing</h1>
+		<p>This page describes the available pricing plans and includes a real data table for comparison.</p>
+		<table>
+			<thead>
+				<tr><th>Plan</th><th>Price</th></tr>
+			</thead>
+			<tbody>
+				<tr><td>Free</td><td>$0</td></tr>
+				<tr><td>Pro</td><td>$20</td></tr>
+			</tbody>
+		</table>
+	</article>
+</body>
+</html>`
+
+	result, err := New().Extract("https://example.com/pricing", html)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	requirePipeTable(t, result.Markdown)
+}
+
+func TestExtractRendersNestedTableContentAsPipeTable(t *testing.T) {
+	t.Parallel()
+
+	html := `<!doctype html>
+<html>
+<head><title>Endpoint Pricing</title></head>
+<body>
+	<main>
+		<article>
+			<h1>Endpoint Pricing</h1>
+			<p>This page compares endpoint pricing across model providers and uses component markup inside table cells.</p>
+			<table role="grid">
+				<thead>
+					<tr><th>Model Name</th><th>Input</th><th>Output</th></tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><div><span>OpenAI</span></div><div><span>gpt-4-turbo</span></div></td>
+						<td><span>$10</span></td>
+						<td><span>$30</span></td>
+					</tr>
+				</tbody>
+			</table>
+		</article>
+	</main>
+</body>
+</html>`
+
+	result, err := New().Extract("https://example.com/pricing", html)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+	requirePipeTable(t, result.Markdown)
+	if !strings.Contains(result.Markdown, "| Model Name | Input | Output |") {
+		t.Fatalf("expected table header row, got:\n%s", result.Markdown)
+	}
+	if !strings.Contains(result.Markdown, "gpt-4-turbo") || !strings.Contains(result.Markdown, "$10") {
+		t.Fatalf("expected table cell content, got:\n%s", result.Markdown)
+	}
+}
+
+func TestExtractSelectorRendersHTMLTableAsPipeTable(t *testing.T) {
+	t.Parallel()
+
+	html := `<!doctype html>
+<html>
+<body>
+	<main>
+		<table>
+			<tr><th>Plan</th><th>Price</th></tr>
+			<tr><td>Free</td><td>$0</td></tr>
+			<tr><td>Pro</td><td>$20</td></tr>
+		</table>
+	</main>
+</body>
+</html>`
+
+	markdown, err := ExtractSelector(html, "main")
+	if err != nil {
+		t.Fatalf("ExtractSelector() error = %v", err)
+	}
+	requirePipeTable(t, markdown)
+}
+
+func requirePipeTable(t *testing.T, markdown string) {
+	t.Helper()
+
+	if !strings.Contains(markdown, "|") {
+		t.Fatalf("expected markdown pipe table, got:\n%s", markdown)
+	}
+	if !strings.Contains(markdown, "---") {
+		t.Fatalf("expected markdown table header separator, got:\n%s", markdown)
+	}
+}

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -1,6 +1,7 @@
 package extract
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -76,6 +77,78 @@ func TestExtractRendersNestedTableContentAsPipeTable(t *testing.T) {
 	}
 }
 
+func TestExtractReinjectsDataTableDroppedByReadability(t *testing.T) {
+	t.Parallel()
+
+	html := largeRankingFixtureHTML(false, "")
+	result, err := New().Extract("https://example.com/economy", html)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+
+	requirePipeTable(t, result.Markdown)
+	for _, want := range []string{
+		"| 1 | United States | 29000 |",
+		"| 2 | China | 18500 |",
+		"| 223 | Economy 223 | 9777 |",
+	} {
+		if !strings.Contains(result.Markdown, want) {
+			t.Fatalf("expected re-injected ranking row %q, got:\n%s", want, result.Markdown)
+		}
+	}
+}
+
+func TestExtractDoesNotDuplicateDataTableKeptByReadability(t *testing.T) {
+	t.Parallel()
+
+	html := largeRankingFixtureHTML(true, "")
+	result, err := New().Extract("https://example.com/economy", html)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+
+	row := "| 1 | United States | 29000 |"
+	if got := strings.Count(result.Markdown, row); got != 1 {
+		t.Fatalf("expected ranking row once, got %d occurrences:\n%s", got, result.Markdown)
+	}
+}
+
+func TestExtractDoesNotReinjectLayoutTable(t *testing.T) {
+	t.Parallel()
+
+	for _, tableClass := range []string{"navbox", "sidebar", "toc", "ambox", "toccolours"} {
+		tableClass := tableClass
+		t.Run(tableClass, func(t *testing.T) {
+			t.Parallel()
+
+			html := largeRankingFixtureHTML(false, tableClass)
+			result, err := New().Extract("https://example.com/economy", html)
+			if err != nil {
+				t.Fatalf("Extract() error = %v", err)
+			}
+
+			if strings.Contains(result.Markdown, "United States") || strings.Contains(result.Markdown, "China") {
+				t.Fatalf("expected layout table to stay out of output, got:\n%s", result.Markdown)
+			}
+		})
+	}
+}
+
+func TestExtractDoesNotReinjectPresentationTable(t *testing.T) {
+	t.Parallel()
+
+	html := largeRankingFixtureHTML(false, "")
+	html = strings.Replace(html, `<table class="wikitable sortable ">`, `<table role="presentation" class="wikitable sortable ">`, 1)
+	result, err := New().Extract("https://example.com/economy", html)
+	if err != nil {
+		t.Fatalf("Extract() error = %v", err)
+	}
+
+	if strings.Contains(result.Markdown, "United States") || strings.Contains(result.Markdown, "China") {
+		t.Fatalf("expected presentation table to stay out of output, got:\n%s", result.Markdown)
+	}
+}
+
 func TestExtractSelectorRendersHTMLTableAsPipeTable(t *testing.T) {
 	t.Parallel()
 
@@ -97,6 +170,58 @@ func TestExtractSelectorRendersHTMLTableAsPipeTable(t *testing.T) {
 		t.Fatalf("ExtractSelector() error = %v", err)
 	}
 	requirePipeTable(t, markdown)
+}
+
+func largeRankingFixtureHTML(tableInsideArticle bool, tableClass string) string {
+	rows := make([]string, 0, 223)
+	seedRows := []struct {
+		rank    int
+		country string
+		gdp     string
+	}{
+		{1, "United States", "29000"},
+		{2, "China", "18500"},
+		{3, "Germany", "4600"},
+		{4, "Japan", "4200"},
+		{5, "India", "3900"},
+		{6, "United Kingdom", "3500"},
+		{7, "France", "3100"},
+		{8, "Italy", "2300"},
+		{9, "Brazil", "2200"},
+		{10, "Canada", "2100"},
+	}
+	for _, row := range seedRows {
+		rows = append(rows, rankingRow(row.rank, row.country, row.gdp))
+	}
+	for rank := 11; rank <= 223; rank++ {
+		rows = append(rows, rankingRow(rank, "Economy "+strconv.Itoa(rank), strconv.Itoa(10000-rank)))
+	}
+
+	table := `<section class="data-section"><h2>GDP ranking</h2><table class="wikitable sortable ` + tableClass + `">
+<thead><tr><th>Rank</th><th>Country</th><th>GDP</th></tr></thead>
+<tbody>` + strings.Join(rows, "\n") + `</tbody>
+</table></section>`
+
+	paragraphs := strings.Repeat(`<p>The economic report explains the current outlook with enough article text for readability to select this article body as the main content.</p>`, 8)
+	article := `<article><h1>Economic report</h1>` + paragraphs + `</article>`
+	if tableInsideArticle {
+		article = `<article><h1>Economic report</h1>` + paragraphs + table + `</article>`
+		table = ""
+	}
+
+	return `<!doctype html>
+<html>
+<head><title>Economic report</title></head>
+<body>
+<header><nav>Home About Contact</nav></header>
+<main>` + article + table + `</main>
+<footer>Footer links</footer>
+</body>
+</html>`
+}
+
+func rankingRow(rank int, country, gdp string) string {
+	return `<tr><td>` + strconv.Itoa(rank) + `</td><td>` + country + `</td><td>` + gdp + `</td></tr>`
 }
 
 func requirePipeTable(t *testing.T, markdown string) {


### PR DESCRIPTION
Fixes #14

Issue #14 was not reliably fixed by adding the table plugin alone because readability can drop large, real data tables from the main extracted subtree (for example, Wikipedia GDP pages). This PR replaces that fallback with a re-injection flow based on deterministic table fingerprints.

### Changes
- Keep the shared `markdownConverter` with `base`, `commonmark`, and `table` plugins.
- Before readability, parse raw HTML and collect data-table candidates using strict criteria:
  - `rows >= 10`, or
  - `columns > 4`, or
  - `<thead>` with `<th>` cells.
- Exclude layout tables when `role="presentation"` or class-name contains any of: `navbox`, `sidebar`, `toc`, `ambox` (case-insensitive substring match).
- For each candidate, compute a normalized fingerprint from cell text (lowercase, whitespace-collapsed, punctuation stripped) and keep outer table HTML.
- Run readability extraction and convert to markdown as before.
- Parse surviving markdown pipe tables, fingerprint them with the same normalizer, and identify missing (dropped) candidates.
- Re-inject only missing tables by converting candidate HTML via `markdownConverter.ConvertString()` and appending to article markdown body.
- Preserve readability title when available; retain original title fallback for raw extraction.

### Behavior
- Pages with no substantial tables: zero candidates, zero re-injection, existing path unchanged.
- Data-heavy pages: readability still gets prose cleanup, while dropped tables are restored as GFM pipe tables.
- Duplicate-safe dedupe by fingerprint so tables kept by readability are not re-appended.

### Testing
- `go test ./...` passed
- Added unit coverage for:
  - readability-dropped large table re-injection,
  - no duplicate re-injection when table survives readability,
  - layout-only tables excluded from re-injection

Note: this PR intentionally uses append-only placement for re-injected tables; in-order reinsertion is deferred to a follow-up.
