### PR TITLE
feat: add keenable search backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ cmd/
   mcp.go                     MCP command: `mcp serve` runs the MCP server over stdio
   proc_unix.go               Unix process management (detach, signals)
   proc_windows.go            Windows process management stub
-search/                      Searcher interface + Brave/DDG/SearXNG/EXA backends; NewFromConfig owns the backend switch for cmd/ and mcp/
+search/                      Searcher interface + Brave/DDG/SearXNG/EXA/Keenable backends; NewFromConfig owns the backend switch for cmd/ and mcp/
 code/                        code.Searcher interface + GrepApp/Sourcegraph/GitHub backends; NewFromConfig owns the backend switch
 docs/                        docs.Searcher interface + Context7 backend (FTS5 local is an unimplemented stub); NewFromConfig owns the backend switch
 mcp/                         MCP server (search/code/docs/scrape/crawl tools) over the go-sdk mcp package; Server struct holds the shared scraper + cache, tools call the same NewFromConfig constructors as the CLI
@@ -76,6 +76,7 @@ ketch search "query"                        # search, return results
 ketch search "query" --scrape               # search + fetch full content
 ketch search "query" -b searxng             # use SearXNG backend
 ketch search "query" -b exa                 # use Exa hosted MCP backend
+ketch search "query" -b keenable            # use Keenable backend (keyless by default)
 ketch scrape <url>                          # single URL → markdown
 ketch scrape <url1> <url2> <url3>           # concurrent batch scrape
 ketch scrape urls.txt                       # file with one URL per line
@@ -104,7 +105,7 @@ ketch mcp serve                             # run as an MCP server over stdio (s
 | Flag | Scope | Default | Description |
 |------|-------|---------|-------------|
 | --json | global | false | JSON output |
-| --backend, -b | search | brave | Search backend (brave/ddg/searxng/exa) |
+| --backend, -b | search | brave | Search backend (brave/ddg/searxng/exa/keenable) |
 | --limit, -l | search | 5 | Max results |
 | --scrape | search | false | Fetch full content |
 | --searxng-url | search | http://localhost:8081 | SearXNG URL |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `keenable` web search backend over the Keenable index, built for AI agents. Keyless by default (public endpoint, rate-limited); an optional `keenable_api_key` lifts the rate limit. Wired into `ketch doctor` as a keyless reachability probe.
 - Claude Code plugin + marketplace manifest: the repo now doubles as a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`) hosting one plugin (`plugins/ketch/`) — `claude plugin marketplace add 1broseidon/ketch`, then `claude plugin install ketch@ketch`. The plugin is an optional convenience for Claude Code users, never a prerequisite (the stateless CLI remains the zero-infrastructure path): it wires up `ketch mcp serve` as a stdio MCP server (`.mcp.json`, expects the ketch binary >= v0.10.0 on PATH — the plugin does not vendor it) and ships the bundled agent skill via a symlink to the canonical copy at [`skills/ketch/`](./skills/ketch/), which stays where it is for non-Claude-Code agents.
 
 ## [0.10.0] - 2026-07-01

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ See [AGENTS.md](AGENTS.md) for full module layout and design principles.
 - `cmd/` — Cobra CLI (root, search, code, docs, scrape, crawl, config, cache, browser, mcp, version)
 - `code/` — `code.Searcher` interface with Grep (built-in default), Sourcegraph, and GitHub backends
 - `docs/` — `docs.Searcher` interface with Context7 backend (local FTS5 planned)
-- `search/` — `Searcher` interface with Brave (built-in default), DDG, SearXNG, and Exa backends
+- `search/` — `Searcher` interface with Brave (built-in default), DDG, SearXNG, Exa, and Keenable backends
 - `scrape/` — HTTP fetch + browser fallback via Rod for JS-rendered pages
 - `extract/` — readability + html-to-markdown pipeline, JS shell detection heuristic
 - `crawl/` — BFS/sitemap crawler with background execution and status tracking
@@ -62,6 +62,7 @@ Use --concurrency N (default 5) to control parallel request limit.
 | `ddg` | Zero config | Rate-limited by DDG currently |
 | `searxng` | Self-hosted instance | Most reliable for heavy use |
 | `exa` | Zero config via hosted MCP; optional `ketch config set exa_api_key <key>` | AI-oriented search with snippets/content from Exa |
+| `keenable` | Zero config (keyless public endpoint); optional `ketch config set keenable_api_key <key>` | Agent-oriented web search over the Keenable index; key lifts the rate limit |
 
 ### Code Backends (ketch code)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A stateless CLI for web search, code search, library docs, and scraping — one 
 
 Most research tooling for agents means wiring up several provider SDKs, each with its own auth and response shape. ketch collapses that into one binary with three research surfaces:
 
-- `ketch search` — web search (Brave, DuckDuckGo, SearXNG, or Exa)
+- `ketch search` — web search (Brave, DuckDuckGo, SearXNG, Exa, or Keenable)
 - `ketch code` — grep real OSS source across public repos (Grep, Sourcegraph, or GitHub Code Search)
 - `ketch docs` — curated, version-aware library documentation (Context7)
 
@@ -89,7 +89,7 @@ ketch scrape https://example.com --json
 
 | Command | What it does |
 |---|---|
-| `search` | Web search — Brave, DuckDuckGo, SearXNG, or Exa |
+| `search` | Web search — Brave, DuckDuckGo, SearXNG, Exa, or Keenable |
 | `code` | Grep real OSS source — Grep (default), Sourcegraph, or GitHub Code Search |
 | `docs` | Library/framework docs — Context7 (curated, version-aware snippets) |
 | `scrape` | Fetch URL(s) and extract clean markdown; concurrent batch, JSON array, file, or stdin input |
@@ -107,7 +107,7 @@ Every command supports `-h/--help` for its full flag list; `--json` is the only 
 
 | Surface | Default | Also available | Setup |
 |---|---|---|---|
-| `search` | `brave` | `ddg`, `searxng`, `exa` | Brave needs a free key (`ketch config set brave_api_key <key>`); the rest work with zero config |
+| `search` | `brave` | `ddg`, `searxng`, `exa`, `keenable` | Brave needs a free key (`ketch config set brave_api_key <key>`); the rest work with zero config |
 | `code` | `grepapp` | `sourcegraph`, `github` | Grep and Sourcegraph need nothing; GitHub uses `gh auth login`, `$GITHUB_TOKEN`, or `ketch config set github_token <tok>` |
 | `docs` | `context7` | `local` (planned, not yet implemented) | Free key: `ketch config set context7_api_key <key>` |
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -149,6 +149,8 @@ func applyConfigSet(c *config.Config, key, value string) error {
 		c.BraveAPIKey = value
 	case "exa_api_key":
 		c.ExaAPIKey = value
+	case "keenable_api_key":
+		c.KeenableAPIKey = value
 	case "limit":
 		return setLimit(c, value)
 	case "cache_ttl":
@@ -170,7 +172,7 @@ func applyConfigSet(c *config.Config, key, value string) error {
 	case "spa_markers":
 		return setSPAMarkers(c, value)
 	default:
-		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, exa_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers)", key)
+		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, exa_api_key, keenable_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers)", key)
 	}
 	return nil
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -18,7 +18,7 @@ import (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search the web and return results",
-	Long:  `Search the web using Brave, DuckDuckGo, SearXNG, or Exa (default: the configured backend; brave if unset). Add --scrape to fetch and extract full content from results.`,
+	Long:  `Search the web using Brave, DuckDuckGo, SearXNG, Exa, or Keenable (default: the configured backend; brave if unset). Add --scrape to fetch and extract full content from results.`,
 	Args:  exitArgs(cobra.MinimumNArgs(1)),
 	RunE:  runSearch,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	SearxngURL     string            `json:"searxng_url"`
 	BraveAPIKey    string            `json:"brave_api_key,omitempty"`
 	ExaAPIKey      string            `json:"exa_api_key,omitempty"`
+	KeenableAPIKey string            `json:"keenable_api_key,omitempty"`
 	Limit          int               `json:"limit"`
 	CacheTTL       string            `json:"cache_ttl"`
 	Browser        string            `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
@@ -71,7 +72,7 @@ func Defaults() Config {
 
 // AvailableBackends returns the list of known search backends.
 func AvailableBackends() []string {
-	return []string{"brave", "ddg", "searxng", "exa"}
+	return []string{"brave", "ddg", "searxng", "exa", "keenable"}
 }
 
 // AvailableCodeBackends returns the list of known code search backends.

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -104,6 +104,7 @@ func Run(ctx context.Context, cfg *config.Config, timeout time.Duration) []Check
 func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 	braveKey := cfg.BraveAPIKey
 	exaKey := cfg.ExaAPIKey
+	keenableKey := cfg.KeenableAPIKey
 	c7Key := cfg.Context7APIKey
 	searxngURL := cfg.SearxngURL
 	sourcegraphURL := cfg.SourcegraphURL
@@ -122,6 +123,9 @@ func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 		}},
 		{"search", "exa", cfg.Backend == "exa" || exaKey != "", func(ctx context.Context) (Status, string) {
 			return probeMCP(ctx, client, exaEndpoint(exaKey), "exa")
+		}},
+		{"search", "keenable", cfg.Backend == "keenable" || keenableKey != "", func(ctx context.Context) (Status, string) {
+			return probeKeenable(ctx, client, keenableEndpoint, keenableKey)
 		}},
 		{"code", "grepapp", cfg.CodeBackend == "grepapp", func(ctx context.Context) (Status, string) {
 			return probeMCP(ctx, client, grepAppEndpoint, "grep.app")

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -193,6 +193,44 @@ func TestProbeMCPServerError(t *testing.T) {
 	}
 }
 
+// --- keenable ---
+
+func TestProbeKeenableKeyless(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.URL.Path; got != "/v1/search/public" {
+			t.Errorf("path = %q, want /v1/search/public (keyless)", got)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "" {
+			t.Errorf("X-API-Key = %q, want empty for keyless", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	status, detail := probeKeenable(testCtx(t), ts.Client(), ts.URL, "")
+	if status != StatusOK {
+		t.Fatalf("status = %q (detail %q), want ok", status, detail)
+	}
+}
+
+func TestProbeKeenableKeyRejected(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/v1/search" {
+			t.Errorf("path = %q, want /v1/search (keyed)", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	status, _ := probeKeenable(testCtx(t), ts.Client(), ts.URL, "bad-key")
+	if status != StatusMisconfigured {
+		t.Fatalf("status = %q, want misconfigured", status)
+	}
+}
+
 // --- sourcegraph reachability ---
 
 func TestProbeReachable(t *testing.T) {
@@ -360,6 +398,9 @@ func TestBuildSpecsRequiredGating(t *testing.T) {
 	}
 	if s := findSpec(t, specs, "search", "ddg"); s.required {
 		t.Error("ddg not default must be informational")
+	}
+	if s := findSpec(t, specs, "search", "keenable"); s.required {
+		t.Error("keenable without a key and not default must be informational")
 	}
 	if s := findSpec(t, specs, "code", "grepapp"); !s.required {
 		t.Error("default code backend must be required")

--- a/doctor/probes.go
+++ b/doctor/probes.go
@@ -20,12 +20,13 @@ import (
 // Production endpoints. Probes take these as parameters so tests can point
 // them at httptest servers.
 const (
-	braveEndpoint   = "https://api.search.brave.com/res/v1/web/search"
-	ddgEndpoint     = "https://html.duckduckgo.com/html/"
-	grepAppEndpoint = "https://mcp.grep.app"
-	exaMCPEndpoint  = "https://mcp.exa.ai/mcp"
-	githubAPIBase   = "https://api.github.com"
-	context7APIBase = "https://context7.com"
+	braveEndpoint    = "https://api.search.brave.com/res/v1/web/search"
+	ddgEndpoint      = "https://html.duckduckgo.com/html/"
+	grepAppEndpoint  = "https://mcp.grep.app"
+	exaMCPEndpoint   = "https://mcp.exa.ai/mcp"
+	keenableEndpoint = "https://api.keenable.ai"
+	githubAPIBase    = "https://api.github.com"
+	context7APIBase  = "https://context7.com"
 )
 
 // ddgUA mirrors the search backend's user agent — DDG's HTML endpoint rejects
@@ -85,6 +86,44 @@ func probeBrave(ctx context.Context, client *http.Client, endpoint, apiKey strin
 		return StatusMisconfigured, "API key rejected (ketch config set brave_api_key <key>)"
 	case http.StatusTooManyRequests:
 		return StatusOK, "reachable, key accepted (rate limited)"
+	default:
+		return StatusUnreachable, fmt.Sprintf("returned status %d", resp.StatusCode)
+	}
+}
+
+// probeKeenable checks the Keenable search API with a minimal query. Keenable
+// is keyless by default (public endpoint); a configured key switches to the
+// authenticated endpoint, so a rejected key surfaces as misconfigured.
+func probeKeenable(ctx context.Context, client *http.Client, base, apiKey string) (Status, string) {
+	key := strings.TrimSpace(apiKey)
+	path := "/v1/search/public"
+	if key != "" {
+		path = "/v1/search"
+	}
+	body := strings.NewReader(`{"query":"ketch","mode":"pro"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+path, body)
+	if err != nil {
+		return StatusUnreachable, probeErrDetail(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Keenable-Title", "Ketch")
+	if key != "" {
+		req.Header.Set("X-API-Key", key)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return StatusUnreachable, probeErrDetail(err)
+	}
+	defer drain(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return StatusOK, ""
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return StatusMisconfigured, "API key rejected (ketch config set keenable_api_key <key>)"
+	case http.StatusTooManyRequests:
+		return StatusOK, "reachable (rate limited; set a key to lift the cap)"
 	default:
 		return StatusUnreachable, fmt.Sprintf("returned status %d", resp.StatusCode)
 	}

--- a/search/config.go
+++ b/search/config.go
@@ -38,6 +38,12 @@ func NewFromConfig(cfg *config.Config, backend, searxngURL string) (Searcher, er
 			apiKey = &cfg.ExaAPIKey
 		}
 		return NewEXA(apiKey), nil
+	case "keenable":
+		var apiKey *string
+		if cfg.KeenableAPIKey != "" {
+			apiKey = &cfg.KeenableAPIKey
+		}
+		return NewKeenable(apiKey), nil
 	default:
 		return nil, fmt.Errorf("%w %q (available: %s)", ErrUnknownBackend, backend, strings.Join(config.AvailableBackends(), ", "))
 	}

--- a/search/keenable.go
+++ b/search/keenable.go
@@ -1,0 +1,126 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/1broseidon/ketch/httpx"
+)
+
+// keenableBaseURL is the Keenable API root. Search hits /v1/search/public
+// (keyless) or /v1/search (keyed); the endpoint is chosen by whether a key is
+// configured.
+const keenableBaseURL = "https://api.keenable.ai"
+
+// keenableTitle is the attribution tag Keenable segments integration traffic
+// by. Sent on every request so ketch usage is visible in adoption dashboards.
+const keenableTitle = "Ketch"
+
+// Keenable searches via the Keenable web search API, a search index built for
+// AI agents. It is keyless by default (rate-limited); an optional API key lifts
+// the hourly cap and switches to the authenticated endpoint.
+type Keenable struct {
+	apiKey *string
+	client *http.Client
+}
+
+// NewKeenable creates a new Keenable search backend. A nil or blank apiKey uses
+// the keyless public endpoint.
+func NewKeenable(apiKey *string) *Keenable {
+	return &Keenable{
+		apiKey: apiKey,
+		client: httpx.Default(),
+	}
+}
+
+type keenableResponse struct {
+	Results []keenableResult `json:"results"`
+}
+
+type keenableResult struct {
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+// Search queries Keenable and returns up to limit results.
+func (k *Keenable) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	if limit <= 0 {
+		return []Result{}, nil
+	}
+
+	body, err := json.Marshal(map[string]any{"query": query, "mode": "pro"})
+	if err != nil {
+		return nil, err
+	}
+
+	// Keyless by default; a configured key switches to the authenticated path.
+	path := "/v1/search/public"
+	key := ""
+	if k.apiKey != nil {
+		key = strings.TrimSpace(*k.apiKey)
+	}
+	if key != "" {
+		path = "/v1/search"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", keenableBaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "keenable-ketch")
+	req.Header.Set("X-Keenable-Title", keenableTitle)
+	if key != "" {
+		req.Header.Set("X-API-Key", key)
+	}
+
+	resp, err := k.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keenable request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("keenable: invalid API key (set via: ketch config set keenable_api_key <key>)")
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("keenable: rate limited (set a key to lift the cap: ketch config set keenable_api_key <key>)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, keenableStatusError(resp)
+	}
+
+	var kr keenableResponse
+	if err := json.NewDecoder(resp.Body).Decode(&kr); err != nil {
+		return nil, fmt.Errorf("failed to decode keenable response: %w", err)
+	}
+
+	results := make([]Result, 0, limit)
+	for _, r := range kr.Results {
+		if len(results) >= limit {
+			break
+		}
+		results = append(results, Result{
+			Title:       r.Title,
+			URL:         r.URL,
+			Description: r.Description,
+		})
+	}
+
+	return results, nil
+}
+
+func keenableStatusError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if detail := strings.TrimSpace(string(body)); detail != "" {
+		return fmt.Errorf("keenable returned status %d: %s", resp.StatusCode, detail)
+	}
+	return fmt.Errorf("keenable returned status %d", resp.StatusCode)
+}

--- a/search/search_feature_test.go
+++ b/search/search_feature_test.go
@@ -499,6 +499,168 @@ func TestFeatureEXAAPIKeyAdded(t *testing.T) {
 	}
 }
 
+func TestFeatureKeenableSearchParses(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"results": [
+				{"title": "Go Docs", "url": "https://go.dev/doc/", "description": "Go documentation"},
+				{"title": "Go Blog", "url": "https://go.dev/blog/", "description": "The Go Blog"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	k := &Keenable{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := k.Search(context.Background(), "golang", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Title != "Go Docs" {
+		t.Errorf("title = %q, want %q", results[0].Title, "Go Docs")
+	}
+	if results[0].URL != "https://go.dev/doc/" {
+		t.Errorf("url = %q, want %q", results[0].URL, "https://go.dev/doc/")
+	}
+	if results[0].Description != "Go documentation" {
+		t.Errorf("description = %q, want %q", results[0].Description, "Go documentation")
+	}
+}
+
+func TestFeatureKeenableKeylessRequestShape(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != "POST" {
+			t.Errorf("method = %q, want POST", got)
+		}
+		// No key configured => keyless public endpoint, no X-API-Key.
+		if got := r.URL.Path; got != "/v1/search/public" {
+			t.Errorf("path = %q, want /v1/search/public", got)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "" {
+			t.Errorf("X-API-Key = %q, want empty for keyless", got)
+		}
+		if got := r.Header.Get("X-Keenable-Title"); got != "Ketch" {
+			t.Errorf("X-Keenable-Title = %q, want Ketch", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body["query"] != "test query" {
+			t.Errorf("query = %q, want test query", body["query"])
+		}
+		if body["mode"] != "pro" {
+			t.Errorf("mode = %q, want pro", body["mode"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[{"title":"A","url":"https://a.com","description":"a"}]}`)
+	}))
+	defer server.Close()
+
+	k := &Keenable{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := k.Search(context.Background(), "test query", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+}
+
+func TestFeatureKeenableKeyedRequestShape(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A configured key switches to the authenticated endpoint + X-API-Key.
+		if got := r.URL.Path; got != "/v1/search" {
+			t.Errorf("path = %q, want /v1/search", got)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "keen_test" {
+			t.Errorf("X-API-Key = %q, want keen_test", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[{"title":"A","url":"https://a.com","description":"a"}]}`)
+	}))
+	defer server.Close()
+
+	key := "keen_test"
+	k := &Keenable{apiKey: &key, client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := k.Search(context.Background(), "test", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+}
+
+func TestFeatureKeenableLimitRespected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[
+			{"title":"A","url":"https://a.com","description":"a"},
+			{"title":"B","url":"https://b.com","description":"b"},
+			{"title":"C","url":"https://c.com","description":"c"}
+		]}`)
+	}))
+	defer server.Close()
+
+	k := &Keenable{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := k.Search(context.Background(), "test", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("got %d results, want 2 (limit)", len(results))
+	}
+}
+
+func TestFeatureKeenableEmptyResults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results": []}`)
+	}))
+	defer server.Close()
+
+	k := &Keenable{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := k.Search(context.Background(), "nothing", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestFeatureKeenable401(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	key := "bad-key"
+	k := &Keenable{apiKey: &key, client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := k.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}
+
+func TestFeatureKeenableServerError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	k := &Keenable{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := k.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
 // rewriteTransport rewrites request URLs to point to the test server.
 type rewriteTransport struct {
 	base   http.RoundTripper

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -6,6 +6,7 @@ This page mirrors the canonical [`CHANGELOG.md`](https://github.com/1broseidon/k
 
 **Added**
 
+- `keenable` web search backend over the Keenable index, built for AI agents. Keyless by default (public endpoint, rate-limited); an optional `keenable_api_key` lifts the rate limit.
 - `exa` web search backend via Exa's hosted MCP endpoint, with optional `exa_api_key` config for authenticated usage.
 
 ## v0.9.3 — 2026-05-29

--- a/site/guide/agent-integration.md
+++ b/site/guide/agent-integration.md
@@ -87,7 +87,7 @@ ketch scrape https://help.example.com/s/article/1234
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "none",
   "github_token_set": false,
-  "available_backends": ["brave", "ddg", "searxng", "exa"],
+  "available_backends": ["brave", "ddg", "searxng", "exa", "keenable"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7"]
 }

--- a/site/guide/configuration.md
+++ b/site/guide/configuration.md
@@ -29,7 +29,7 @@ The discovery payload:
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "none",
   "github_token_set": false,
-  "available_backends": ["brave", "ddg", "searxng", "exa"],
+  "available_backends": ["brave", "ddg", "searxng", "exa", "keenable"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7"]
 }
@@ -48,6 +48,7 @@ ketch config set backend searxng
 ketch config set brave_api_key BSA...
 ketch config set searxng_url http://my-searxng:8080
 ketch config set exa_api_key exa...
+ketch config set keenable_api_key keen_...
 ketch config set limit 10
 ketch config set cache_ttl 4h
 ketch config set browser chrome
@@ -63,9 +64,10 @@ ketch config set github_token ghp_...
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `backend` | `brave` | Default search backend: `brave`, `ddg`, `searxng`, `exa` |
+| `backend` | `brave` | Default search backend: `brave`, `ddg`, `searxng`, `exa`, `keenable` |
 | `brave_api_key` | — | Brave Search API key ([get one free](https://brave.com/search/api/)) |
 | `exa_api_key` | — | Optional Exa API key for authenticated hosted MCP usage |
+| `keenable_api_key` | — | Optional Keenable API key; keyless by default, a key lifts the rate limit ([console](https://keenable.ai/console)) |
 | `searxng_url` | `http://localhost:8081` | SearXNG instance URL |
 | `limit` | `5` | Default max results (shared by `search`, `code`, `docs`) |
 
@@ -87,7 +89,7 @@ ketch config set github_token ghp_...
 | `browser` | — | Browser for JS-rendered pages: `chrome`, `chromium`, or absolute path |
 | `url_rewrites` | — | Ordered regex rewrite rules applied before every fetch (see below) |
 
-Secrets (`brave_api_key`, `exa_api_key`, `context7_api_key`, `github_token`) are stored in
+Secrets (`brave_api_key`, `exa_api_key`, `keenable_api_key`, `context7_api_key`, `github_token`) are stored in
 plaintext in `config.json`; protect the file accordingly.
 
 ## URL Rewrites

--- a/site/reference/backends.md
+++ b/site/reference/backends.md
@@ -4,7 +4,7 @@ ketch has three search surfaces, each with its own backends: web search (`ketch 
 
 ## Web Search Backends
 
-ketch supports four web-search backends. Set the default with `ketch config set backend <name>`.
+ketch supports five web-search backends. Set the default with `ketch config set backend <name>`.
 
 ## Brave (default)
 
@@ -60,6 +60,21 @@ ketch config set backend exa
 ```
 
 **Recommended for:** agent workflows that benefit from Exa's clean result snippets and content-oriented search output.
+
+## Keenable
+
+Web search built for AI agents, backed by the Keenable index. Keyless by default — it works with no account or key against the public endpoint (rate-limited); an optional API key lifts the hourly cap.
+
+**Setup:** None. Optional key to lift the rate limit:
+
+```sh
+ketch config set keenable_api_key <your-key>
+ketch config set backend keenable
+```
+
+Create a key at [keenable.ai/console](https://keenable.ai/console).
+
+**Recommended for:** agent workflows that want a zero-config, agent-oriented search backend without provisioning a provider key up front.
 
 ## Code Search Backends
 

--- a/site/reference/commands.md
+++ b/site/reference/commands.md
@@ -12,7 +12,7 @@ ketch search <query> [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--backend, -b` | `brave` | Search backend: `brave`, `ddg`, `searxng`, `exa` |
+| `--backend, -b` | `brave` | Search backend: `brave`, `ddg`, `searxng`, `exa`, `keenable` |
 | `--limit, -l` | `5` | Max number of results |
 | `--scrape` | `false` | Fetch full content from each result |
 | `--minimal` | `false` | One result per line, tab-separated |
@@ -30,6 +30,7 @@ ketch search "rust async" --limit 10
 ketch search "python web scraping" --scrape
 ketch search "query" --backend searxng
 ketch search "query" --backend exa
+ketch search "query" --backend keenable
 ketch search "query" --json
 ```
 


### PR DESCRIPTION
Adds **Keenable** as a `ketch search` backend, alongside brave/ddg/searxng/exa. Keenable is a web search index built for AI agents.

## Why

Unlike Brave and Exa, Keenable is **keyless by default**: it works with zero config against the public endpoint (rate-limited). An optional `keenable_api_key` switches to the authenticated endpoint and lifts the rate limit. So it drops into the same "zero config" tier as `ddg`/`searxng`, with no provider key to provision up front.

## What

- `search/keenable.go`: `Searcher` implementation. Plain JSON `POST`; no key hits `/v1/search/public`, a configured key hits `/v1/search` with an `X-API-Key` header.
- `search/config.go`: wire `keenable` into `NewFromConfig` (the single backend switch shared by CLI and MCP).
- `config`: `KeenableAPIKey` field, `keenable_api_key` set-key, `keenable` in `AvailableBackends()`.
- `doctor`: keyless reachability probe for the `keenable` surface (informational unless it is the default backend or a key is set, matching `exa`).
- Tests: parse / limit / empty / 401 / 500, plus keyless-vs-keyed request shape, plus the doctor probe and exit-gating assertions.
- Docs: README, AGENTS, CLAUDE, `site/reference/{backends,commands}.md`, `site/guide/{configuration,agent-integration}.md`, CHANGELOG + site changelog.

## Usage

```sh
ketch search "golang error handling" -b keenable      # keyless, works out of the box
ketch config set keenable_api_key keen_...             # optional: lift the rate limit
ketch config set backend keenable                      # make it the default
```

Follows the structure of the existing Exa backend (#10). `gofmt`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)