### PR TITLE
feat: add Firecrawl web search backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ cmd/
   mcp.go                     MCP command: `mcp serve` runs the MCP server over stdio
   proc_unix.go               Unix process management (detach, signals)
   proc_windows.go            Windows process management stub
-search/                      Searcher interface + Brave/DDG/SearXNG/EXA backends; NewFromConfig owns the backend switch for cmd/ and mcp/
+search/                      Searcher interface + Brave/DDG/SearXNG/EXA/Firecrawl backends; NewFromConfig owns the backend switch for cmd/ and mcp/
 code/                        code.Searcher interface + GrepApp/Sourcegraph/GitHub backends; NewFromConfig owns the backend switch
 docs/                        docs.Searcher interface + Context7 backend (FTS5 local is an unimplemented stub); NewFromConfig owns the backend switch
 mcp/                         MCP server (search/code/docs/scrape/crawl tools) over the go-sdk mcp package; Server struct holds the shared scraper + cache, tools call the same NewFromConfig constructors as the CLI
@@ -76,6 +76,7 @@ ketch search "query"                        # search, return results
 ketch search "query" --scrape               # search + fetch full content
 ketch search "query" -b searxng             # use SearXNG backend
 ketch search "query" -b exa                 # use Exa hosted MCP backend
+ketch search "query" -b firecrawl           # use Firecrawl v2 search API
 ketch scrape <url>                          # single URL → markdown
 ketch scrape <url1> <url2> <url3>           # concurrent batch scrape
 ketch scrape urls.txt                       # file with one URL per line
@@ -104,7 +105,7 @@ ketch mcp serve                             # run as an MCP server over stdio (s
 | Flag | Scope | Default | Description |
 |------|-------|---------|-------------|
 | --json | global | false | JSON output |
-| --backend, -b | search | brave | Search backend (brave/ddg/searxng/exa) |
+| --backend, -b | search | brave | Search backend (brave/ddg/searxng/exa/firecrawl) |
 | --limit, -l | search | 5 | Max results |
 | --scrape | search | false | Fetch full content |
 | --searxng-url | search | http://localhost:8081 | SearXNG URL |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `firecrawl` web search backend via the [Firecrawl](https://docs.firecrawl.dev) v2 search API (`POST /v2/search`), configured with `ketch config set firecrawl_api_key <key>` and selected with `ketch config set backend firecrawl` or `ketch search -b firecrawl`. Uses the shared `httpx` client and slots into the existing `search.Searcher` interface / `NewFromConfig` switch like the other backends. `ketch config` discovery reports `firecrawl_api_key_set`, and `ketch doctor` gains a live search-backend probe (`ok` / `no_key` / `misconfigured` / `unreachable`). Same provider that powers Firecrawl scrape/crawl workflows, for operators who want one key for both search and page extraction.
 - Claude Code plugin + marketplace manifest: the repo now doubles as a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`) hosting one plugin (`plugins/ketch/`) — `claude plugin marketplace add 1broseidon/ketch`, then `claude plugin install ketch@ketch`. The plugin is an optional convenience for Claude Code users, never a prerequisite (the stateless CLI remains the zero-infrastructure path): it wires up `ketch mcp serve` as a stdio MCP server (`.mcp.json`, expects the ketch binary >= v0.10.0 on PATH — the plugin does not vendor it) and ships the bundled agent skill via a symlink to the canonical copy at [`skills/ketch/`](./skills/ketch/), which stays where it is for non-Claude-Code agents.
 
 ## [0.10.0] - 2026-07-01

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ See [AGENTS.md](AGENTS.md) for full module layout and design principles.
 - `cmd/` — Cobra CLI (root, search, code, docs, scrape, crawl, config, cache, browser, mcp, version)
 - `code/` — `code.Searcher` interface with Grep (built-in default), Sourcegraph, and GitHub backends
 - `docs/` — `docs.Searcher` interface with Context7 backend (local FTS5 planned)
-- `search/` — `Searcher` interface with Brave (built-in default), DDG, SearXNG, and Exa backends
+- `search/` — `Searcher` interface with Brave (built-in default), DDG, SearXNG, Exa, and Firecrawl backends
 - `scrape/` — HTTP fetch + browser fallback via Rod for JS-rendered pages
 - `extract/` — readability + html-to-markdown pipeline, JS shell detection heuristic
 - `crawl/` — BFS/sitemap crawler with background execution and status tracking
@@ -62,6 +62,7 @@ Use --concurrency N (default 5) to control parallel request limit.
 | `ddg` | Zero config | Rate-limited by DDG currently |
 | `searxng` | Self-hosted instance | Most reliable for heavy use |
 | `exa` | Zero config via hosted MCP; optional `ketch config set exa_api_key <key>` | AI-oriented search with snippets/content from Exa |
+| `firecrawl` | API key: `ketch config set firecrawl_api_key <key>` | Firecrawl v2 search API; same provider as scrape/crawl workflows |
 
 ### Code Backends (ketch code)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A stateless CLI for web search, code search, library docs, and scraping — one 
 
 Most research tooling for agents means wiring up several provider SDKs, each with its own auth and response shape. ketch collapses that into one binary with three research surfaces:
 
-- `ketch search` — web search (Brave, DuckDuckGo, SearXNG, or Exa)
+- `ketch search` — web search (Brave, DuckDuckGo, SearXNG, Exa, or Firecrawl)
 - `ketch code` — grep real OSS source across public repos (Grep, Sourcegraph, or GitHub Code Search)
 - `ketch docs` — curated, version-aware library documentation (Context7)
 
@@ -89,7 +89,7 @@ ketch scrape https://example.com --json
 
 | Command | What it does |
 |---|---|
-| `search` | Web search — Brave, DuckDuckGo, SearXNG, or Exa |
+| `search` | Web search — Brave, DuckDuckGo, SearXNG, Exa, or Firecrawl |
 | `code` | Grep real OSS source — Grep (default), Sourcegraph, or GitHub Code Search |
 | `docs` | Library/framework docs — Context7 (curated, version-aware snippets) |
 | `scrape` | Fetch URL(s) and extract clean markdown; concurrent batch, JSON array, file, or stdin input |
@@ -107,7 +107,7 @@ Every command supports `-h/--help` for its full flag list; `--json` is the only 
 
 | Surface | Default | Also available | Setup |
 |---|---|---|---|
-| `search` | `brave` | `ddg`, `searxng`, `exa` | Brave needs a free key (`ketch config set brave_api_key <key>`); the rest work with zero config |
+| `search` | `brave` | `ddg`, `searxng`, `exa`, `firecrawl` | Brave and Firecrawl need a free key (`ketch config set brave_api_key <key>` / `firecrawl_api_key`); `ddg`, `searxng`, and `exa` work with zero config |
 | `code` | `grepapp` | `sourcegraph`, `github` | Grep and Sourcegraph need nothing; GitHub uses `gh auth login`, `$GITHUB_TOKEN`, or `ketch config set github_token <tok>` |
 | `docs` | `context7` | `local` (planned, not yet implemented) | Free key: `ketch config set context7_api_key <key>` |
 
@@ -133,7 +133,7 @@ ketch config                               # print effective config + available 
 ketch config path                          # print the config file path
 ```
 
-Other configurable keys include per-backend API keys and URLs (`brave_api_key`, `context7_api_key`, `github_token`, `sourcegraph_url`, `exa_api_key`), `cache_ttl`, `url_rewrites` (regex rewrite rules applied before fetch), and `spa_markers` (extra JS-shell detection tokens). See the [config reference](https://1broseidon.github.io/ketch/) for the full list.
+Other configurable keys include per-backend API keys and URLs (`brave_api_key`, `context7_api_key`, `github_token`, `sourcegraph_url`, `exa_api_key`, `firecrawl_api_key`), `cache_ttl`, `url_rewrites` (regex rewrite rules applied before fetch), and `spa_markers` (extra JS-shell detection tokens). See the [config reference](https://1broseidon.github.io/ketch/) for the full list.
 
 ## Agent integration
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,6 +24,7 @@ type configInfo struct {
 	SearxngURL            string            `json:"searxng_url"`
 	BraveAPIKeySet        bool              `json:"brave_api_key_set"`
 	ExaAPIKeySet          bool              `json:"exa_api_key_set"`
+	FirecrawlAPIKeySet    bool              `json:"firecrawl_api_key_set"`
 	Limit                 int               `json:"limit"`
 	CacheTTL              string            `json:"cache_ttl"`
 	Browser               string            `json:"browser,omitempty"`
@@ -84,6 +85,7 @@ func runConfigShow(_ *cobra.Command, _ []string) error {
 		SearxngURL:            c.SearxngURL,
 		BraveAPIKeySet:        c.BraveAPIKey != "",
 		ExaAPIKeySet:          c.ExaAPIKey != "",
+		FirecrawlAPIKeySet:    c.FirecrawlAPIKey != "",
 		Limit:                 c.Limit,
 		CacheTTL:              c.CacheTTL,
 		Browser:               c.Browser,
@@ -139,6 +141,10 @@ func runConfigSet(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+// applyConfigSet is a flat key→field dispatch; its cyclomatic complexity scales
+// with the number of config keys, not with any real branching depth.
+//
+//nolint:gocyclo // one arm per config key; splitting it would obscure, not clarify
 func applyConfigSet(c *config.Config, key, value string) error {
 	switch key {
 	case "backend":
@@ -149,6 +155,8 @@ func applyConfigSet(c *config.Config, key, value string) error {
 		c.BraveAPIKey = value
 	case "exa_api_key":
 		c.ExaAPIKey = value
+	case "firecrawl_api_key":
+		c.FirecrawlAPIKey = value
 	case "limit":
 		return setLimit(c, value)
 	case "cache_ttl":
@@ -170,7 +178,7 @@ func applyConfigSet(c *config.Config, key, value string) error {
 	case "spa_markers":
 		return setSPAMarkers(c, value)
 	default:
-		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, exa_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers)", key)
+		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, exa_api_key, firecrawl_api_key, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers)", key)
 	}
 	return nil
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -18,7 +18,7 @@ import (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search the web and return results",
-	Long:  `Search the web using Brave, DuckDuckGo, SearXNG, or Exa (default: the configured backend; brave if unset). Add --scrape to fetch and extract full content from results.`,
+	Long:  `Search the web using Brave, DuckDuckGo, SearXNG, Exa, or Firecrawl (default: the configured backend; brave if unset). Add --scrape to fetch and extract full content from results.`,
 	Args:  exitArgs(cobra.MinimumNArgs(1)),
 	RunE:  runSearch,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -14,20 +14,21 @@ import (
 
 // Config holds user-configurable defaults for ketch.
 type Config struct {
-	Backend        string            `json:"backend"`
-	SearxngURL     string            `json:"searxng_url"`
-	BraveAPIKey    string            `json:"brave_api_key,omitempty"`
-	ExaAPIKey      string            `json:"exa_api_key,omitempty"`
-	Limit          int               `json:"limit"`
-	CacheTTL       string            `json:"cache_ttl"`
-	Browser        string            `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
-	CodeBackend    string            `json:"code_backend,omitempty"`
-	DocsBackend    string            `json:"docs_backend,omitempty"`
-	Context7APIKey string            `json:"context7_api_key,omitempty"`
-	SourcegraphURL string            `json:"sourcegraph_url,omitempty"`
-	GithubToken    string            `json:"github_token,omitempty"`
-	URLRewrites    []urlrewrite.Rule `json:"url_rewrites,omitempty"`
-	SPAMarkers     []string          `json:"spa_markers,omitempty"`
+	Backend         string            `json:"backend"`
+	SearxngURL      string            `json:"searxng_url"`
+	BraveAPIKey     string            `json:"brave_api_key,omitempty"`
+	ExaAPIKey       string            `json:"exa_api_key,omitempty"`
+	FirecrawlAPIKey string            `json:"firecrawl_api_key,omitempty"`
+	Limit           int               `json:"limit"`
+	CacheTTL        string            `json:"cache_ttl"`
+	Browser         string            `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
+	CodeBackend     string            `json:"code_backend,omitempty"`
+	DocsBackend     string            `json:"docs_backend,omitempty"`
+	Context7APIKey  string            `json:"context7_api_key,omitempty"`
+	SourcegraphURL  string            `json:"sourcegraph_url,omitempty"`
+	GithubToken     string            `json:"github_token,omitempty"`
+	URLRewrites     []urlrewrite.Rule `json:"url_rewrites,omitempty"`
+	SPAMarkers      []string          `json:"spa_markers,omitempty"`
 }
 
 // ResolveGithubToken returns a token and the source it came from, walking the
@@ -71,7 +72,7 @@ func Defaults() Config {
 
 // AvailableBackends returns the list of known search backends.
 func AvailableBackends() []string {
-	return []string{"brave", "ddg", "searxng", "exa"}
+	return []string{"brave", "ddg", "searxng", "exa", "firecrawl"}
 }
 
 // AvailableCodeBackends returns the list of known code search backends.

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -104,6 +104,7 @@ func Run(ctx context.Context, cfg *config.Config, timeout time.Duration) []Check
 func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 	braveKey := cfg.BraveAPIKey
 	exaKey := cfg.ExaAPIKey
+	firecrawlKey := cfg.FirecrawlAPIKey
 	c7Key := cfg.Context7APIKey
 	searxngURL := cfg.SearxngURL
 	sourcegraphURL := cfg.SourcegraphURL
@@ -122,6 +123,9 @@ func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 		}},
 		{"search", "exa", cfg.Backend == "exa" || exaKey != "", func(ctx context.Context) (Status, string) {
 			return probeMCP(ctx, client, exaEndpoint(exaKey), "exa")
+		}},
+		{"search", "firecrawl", cfg.Backend == "firecrawl" || firecrawlKey != "", func(ctx context.Context) (Status, string) {
+			return probeFirecrawl(ctx, client, firecrawlSearch, firecrawlKey)
 		}},
 		{"code", "grepapp", cfg.CodeBackend == "grepapp", func(ctx context.Context) (Status, string) {
 			return probeMCP(ctx, client, grepAppEndpoint, "grep.app")

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -106,6 +106,55 @@ func TestProbeBraveNoKey(t *testing.T) {
 	}
 }
 
+func TestProbeFirecrawlNoKey(t *testing.T) {
+	// Must classify without any network call: the handler fails the test.
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("no-key probe must not hit the network")
+	}))
+	defer ts.Close()
+
+	status, detail := probeFirecrawl(testCtx(t), ts.Client(), ts.URL, "")
+	if status != StatusNoKey {
+		t.Fatalf("status = %q, want no_key", status)
+	}
+	if !strings.Contains(detail, "firecrawl_api_key") {
+		t.Errorf("detail %q should carry the config hint", detail)
+	}
+}
+
+func TestProbeFirecrawlStatuses(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want Status
+	}{
+		{"ok", http.StatusOK, StatusOK},
+		{"invalid key", http.StatusUnauthorized, StatusMisconfigured},
+		{"payment required", http.StatusPaymentRequired, StatusMisconfigured},
+		{"rate limited", http.StatusTooManyRequests, StatusOK},
+		{"server error", http.StatusBadGateway, StatusUnreachable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Method; got != http.MethodPost {
+					t.Errorf("method = %q, want POST", got)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer k" {
+					t.Errorf("Authorization = %q, want Bearer k", got)
+				}
+				w.WriteHeader(tc.code)
+			}))
+			defer ts.Close()
+
+			status, _ := probeFirecrawl(testCtx(t), ts.Client(), ts.URL, "k")
+			if status != tc.want {
+				t.Fatalf("status = %q, want %q", status, tc.want)
+			}
+		})
+	}
+}
+
 func TestProbeBraveStatuses(t *testing.T) {
 	cases := []struct {
 		name string

--- a/doctor/probes.go
+++ b/doctor/probes.go
@@ -24,6 +24,7 @@ const (
 	ddgEndpoint     = "https://html.duckduckgo.com/html/"
 	grepAppEndpoint = "https://mcp.grep.app"
 	exaMCPEndpoint  = "https://mcp.exa.ai/mcp"
+	firecrawlSearch = "https://api.firecrawl.dev/v2/search"
 	githubAPIBase   = "https://api.github.com"
 	context7APIBase = "https://context7.com"
 )
@@ -83,6 +84,37 @@ func probeBrave(ctx context.Context, client *http.Client, endpoint, apiKey strin
 		return StatusOK, ""
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return StatusMisconfigured, "API key rejected (ketch config set brave_api_key <key>)"
+	case http.StatusTooManyRequests:
+		return StatusOK, "reachable, key accepted (rate limited)"
+	default:
+		return StatusUnreachable, fmt.Sprintf("returned status %d", resp.StatusCode)
+	}
+}
+
+// probeFirecrawl checks the Firecrawl v2 search API with a minimal one-result
+// query. Firecrawl requires an API key, so a missing key is a clean no_key.
+func probeFirecrawl(ctx context.Context, client *http.Client, endpoint, apiKey string) (Status, string) {
+	if apiKey == "" {
+		return StatusNoKey, "API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(`{"query":"ketch","limit":1}`))
+	if err != nil {
+		return StatusUnreachable, probeErrDetail(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return StatusUnreachable, probeErrDetail(err)
+	}
+	defer drain(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return StatusOK, ""
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired:
+		return StatusMisconfigured, "API key rejected (ketch config set firecrawl_api_key <key>)"
 	case http.StatusTooManyRequests:
 		return StatusOK, "reachable, key accepted (rate limited)"
 	default:

--- a/mcp/search.go
+++ b/mcp/search.go
@@ -13,7 +13,7 @@ import (
 // default backend/limit) stay operator-configured.
 type SearchInput struct {
 	Query      string `json:"query" jsonschema:"the search query"`
-	Backend    string `json:"backend,omitempty" jsonschema:"search backend: brave, ddg, searxng, or exa (default: the configured backend)"`
+	Backend    string `json:"backend,omitempty" jsonschema:"search backend: brave, ddg, searxng, exa, or firecrawl (default: the configured backend)"`
 	Limit      int    `json:"limit,omitempty" jsonschema:"max number of results (default: the configured limit)"`
 	SearxngURL string `json:"searxng_url,omitempty" jsonschema:"override the configured SearXNG instance URL (searxng backend only)"`
 	Scrape     bool   `json:"scrape,omitempty" jsonschema:"also fetch each result URL and fill its content field with extracted markdown"`

--- a/search/config.go
+++ b/search/config.go
@@ -38,6 +38,11 @@ func NewFromConfig(cfg *config.Config, backend, searxngURL string) (Searcher, er
 			apiKey = &cfg.ExaAPIKey
 		}
 		return NewEXA(apiKey), nil
+	case "firecrawl":
+		if cfg.FirecrawlAPIKey == "" {
+			return nil, fmt.Errorf("firecrawl: API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)")
+		}
+		return NewFirecrawl(cfg.FirecrawlAPIKey), nil
 	default:
 		return nil, fmt.Errorf("%w %q (available: %s)", ErrUnknownBackend, backend, strings.Join(config.AvailableBackends(), ", "))
 	}

--- a/search/firecrawl.go
+++ b/search/firecrawl.go
@@ -1,0 +1,119 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/1broseidon/ketch/httpx"
+)
+
+// firecrawlSearchEndpoint is the Firecrawl v2 search API. See
+// https://docs.firecrawl.dev/api-reference/endpoint/search.
+const firecrawlSearchEndpoint = "https://api.firecrawl.dev/v2/search"
+
+// Firecrawl searches the web via the Firecrawl v2 search API.
+type Firecrawl struct {
+	apiKey string
+	client *http.Client
+}
+
+// NewFirecrawl creates a new Firecrawl search backend.
+func NewFirecrawl(apiKey string) *Firecrawl {
+	return &Firecrawl{
+		apiKey: apiKey,
+		client: httpx.Default(),
+	}
+}
+
+type firecrawlRequest struct {
+	Query       string `json:"query"`
+	Limit       int    `json:"limit"`
+	Integration string `json:"integration,omitempty"`
+}
+
+type firecrawlResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Web []firecrawlResult `json:"web"`
+	} `json:"data"`
+}
+
+type firecrawlResult struct {
+	Title       string `json:"title"`
+	URL         string `json:"url"`
+	Description string `json:"description"`
+}
+
+// Search queries Firecrawl and returns up to limit web results.
+func (f *Firecrawl) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	if limit <= 0 {
+		return []Result{}, nil
+	}
+
+	body, err := json.Marshal(firecrawlRequest{
+		Query:       query,
+		Limit:       limit,
+		Integration: "_ketch",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", firecrawlSearchEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+f.apiKey)
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("firecrawl request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusPaymentRequired {
+		return nil, fmt.Errorf("firecrawl: invalid API key (set via: ketch config set firecrawl_api_key <key>)")
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("firecrawl: rate limited")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, firecrawlStatusError(resp)
+	}
+
+	var fr firecrawlResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
+		return nil, fmt.Errorf("failed to decode firecrawl response: %w", err)
+	}
+
+	results := make([]Result, 0, limit)
+	for _, r := range fr.Data.Web {
+		if len(results) >= limit {
+			break
+		}
+		if r.URL == "" {
+			continue
+		}
+		results = append(results, Result{
+			Title:       r.Title,
+			URL:         r.URL,
+			Description: r.Description,
+		})
+	}
+
+	return results, nil
+}
+
+func firecrawlStatusError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if detail := strings.TrimSpace(string(body)); detail != "" {
+		return fmt.Errorf("firecrawl returned status %d: %s", resp.StatusCode, detail)
+	}
+	return fmt.Errorf("firecrawl returned status %d", resp.StatusCode)
+}

--- a/search/search_feature_test.go
+++ b/search/search_feature_test.go
@@ -499,6 +499,142 @@ func TestFeatureEXAAPIKeyAdded(t *testing.T) {
 	}
 }
 
+func TestFeatureFirecrawlSearchParses(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"web":[
+			{"url":"https://go.dev/blog/error-handling-and-go","title":"Error handling and Go","description":"Go code uses error values."},
+			{"url":"https://go.dev/doc/","title":"Go Docs","description":"Go documentation"}
+		]}}`)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{apiKey: "k", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := f.Search(context.Background(), "golang error handling", 5)
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Title != "Error handling and Go" {
+		t.Errorf("title = %q, want %q", results[0].Title, "Error handling and Go")
+	}
+	if results[0].URL != "https://go.dev/blog/error-handling-and-go" {
+		t.Errorf("url = %q, want blog URL", results[0].URL)
+	}
+	if results[0].Description != "Go code uses error values." {
+		t.Errorf("description = %q, want snippet", results[0].Description)
+	}
+}
+
+func TestFeatureFirecrawlRequestShape(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Method; got != http.MethodPost {
+			t.Errorf("method = %q, want POST", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body["query"] != "rust release date" {
+			t.Errorf("query = %q, want rust release date", body["query"])
+		}
+		if body["limit"] != float64(5) {
+			t.Errorf("limit = %v, want 5", body["limit"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"web":[{"url":"https://www.rust-lang.org/","title":"Rust","description":"Rust"}]}}`)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{apiKey: "test-key", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := f.Search(context.Background(), "rust release date", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+}
+
+func TestFeatureFirecrawlLimitRespected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"web":[
+			{"url":"https://a.com","title":"A","description":"a"},
+			{"url":"https://b.com","title":"B","description":"b"},
+			{"url":"https://c.com","title":"C","description":"c"}
+		]}}`)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{apiKey: "k", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := f.Search(context.Background(), "test", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Errorf("got %d results, want 2 (limit)", len(results))
+	}
+}
+
+func TestFeatureFirecrawlEmptyResults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"web":[]}}`)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{apiKey: "k", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := f.Search(context.Background(), "nothing", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestFeatureFirecrawlInvalidKey(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{apiKey: "bad-key", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := f.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !strings.Contains(err.Error(), "firecrawl_api_key") {
+		t.Errorf("error %q should carry the config hint", err.Error())
+	}
+}
+
+func TestFeatureFirecrawlServerError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{apiKey: "k", client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	_, err := f.Search(context.Background(), "test", 5)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
 // rewriteTransport rewrites request URLs to point to the test server.
 type rewriteTransport struct {
 	base   http.RoundTripper

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -6,6 +6,7 @@ This page mirrors the canonical [`CHANGELOG.md`](https://github.com/1broseidon/k
 
 **Added**
 
+- `firecrawl` web search backend via the [Firecrawl](https://docs.firecrawl.dev) v2 search API, configured with `ketch config set firecrawl_api_key <key>` and selected with `-b firecrawl`. Reports `firecrawl_api_key_set` in `ketch config` discovery and is covered by a live `ketch doctor` probe.
 - `exa` web search backend via Exa's hosted MCP endpoint, with optional `exa_api_key` config for authenticated usage.
 
 ## v0.9.3 — 2026-05-29

--- a/site/guide/agent-integration.md
+++ b/site/guide/agent-integration.md
@@ -78,6 +78,7 @@ ketch scrape https://help.example.com/s/article/1234
   "searxng_url": "http://localhost:8081",
   "brave_api_key_set": false,
   "exa_api_key_set": false,
+  "firecrawl_api_key_set": false,
   "limit": 5,
   "cache_ttl": "72h",
   "browser": "chrome",
@@ -87,7 +88,7 @@ ketch scrape https://help.example.com/s/article/1234
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "none",
   "github_token_set": false,
-  "available_backends": ["brave", "ddg", "searxng", "exa"],
+  "available_backends": ["brave", "ddg", "searxng", "exa", "firecrawl"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7"]
 }

--- a/site/guide/configuration.md
+++ b/site/guide/configuration.md
@@ -21,6 +21,7 @@ The discovery payload:
   "searxng_url": "http://localhost:8081",
   "brave_api_key_set": false,
   "exa_api_key_set": false,
+  "firecrawl_api_key_set": false,
   "limit": 5,
   "cache_ttl": "72h",
   "code_backend": "grepapp",
@@ -29,7 +30,7 @@ The discovery payload:
   "sourcegraph_url": "https://sourcegraph.com",
   "github_token_source": "none",
   "github_token_set": false,
-  "available_backends": ["brave", "ddg", "searxng", "exa"],
+  "available_backends": ["brave", "ddg", "searxng", "exa", "firecrawl"],
   "available_code_backends": ["grepapp", "sourcegraph", "github"],
   "available_doc_backends": ["context7"]
 }
@@ -48,6 +49,7 @@ ketch config set backend searxng
 ketch config set brave_api_key BSA...
 ketch config set searxng_url http://my-searxng:8080
 ketch config set exa_api_key exa...
+ketch config set firecrawl_api_key fc-...
 ketch config set limit 10
 ketch config set cache_ttl 4h
 ketch config set browser chrome
@@ -63,9 +65,10 @@ ketch config set github_token ghp_...
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `backend` | `brave` | Default search backend: `brave`, `ddg`, `searxng`, `exa` |
+| `backend` | `brave` | Default search backend: `brave`, `ddg`, `searxng`, `exa`, `firecrawl` |
 | `brave_api_key` | — | Brave Search API key ([get one free](https://brave.com/search/api/)) |
 | `exa_api_key` | — | Optional Exa API key for authenticated hosted MCP usage |
+| `firecrawl_api_key` | — | [Firecrawl](https://docs.firecrawl.dev) API key (required for `-b firecrawl`) |
 | `searxng_url` | `http://localhost:8081` | SearXNG instance URL |
 | `limit` | `5` | Default max results (shared by `search`, `code`, `docs`) |
 
@@ -87,7 +90,7 @@ ketch config set github_token ghp_...
 | `browser` | — | Browser for JS-rendered pages: `chrome`, `chromium`, or absolute path |
 | `url_rewrites` | — | Ordered regex rewrite rules applied before every fetch (see below) |
 
-Secrets (`brave_api_key`, `exa_api_key`, `context7_api_key`, `github_token`) are stored in
+Secrets (`brave_api_key`, `exa_api_key`, `firecrawl_api_key`, `context7_api_key`, `github_token`) are stored in
 plaintext in `config.json`; protect the file accordingly.
 
 ## URL Rewrites

--- a/site/reference/backends.md
+++ b/site/reference/backends.md
@@ -4,7 +4,7 @@ ketch has three search surfaces, each with its own backends: web search (`ketch 
 
 ## Web Search Backends
 
-ketch supports four web-search backends. Set the default with `ketch config set backend <name>`.
+ketch supports five web-search backends. Set the default with `ketch config set backend <name>`.
 
 ## Brave (default)
 
@@ -60,6 +60,18 @@ ketch config set backend exa
 ```
 
 **Recommended for:** agent workflows that benefit from Exa's clean result snippets and content-oriented search output.
+
+## Firecrawl
+
+Web search via the [Firecrawl](https://firecrawl.dev) v2 [search API](https://docs.firecrawl.dev/api-reference/endpoint/search) — proper JSON API, no scraping. Requires an API key.
+
+**Setup:**
+
+1. Get an API key at [firecrawl.dev](https://firecrawl.dev)
+2. Set it: `ketch config set firecrawl_api_key <your-key>`
+3. Make it the default: `ketch config set backend firecrawl`
+
+**Recommended for:** operators already using Firecrawl for scraping who want a single provider for both search and page extraction. Pair with `--scrape` to fetch full content per result.
 
 ## Code Search Backends
 

--- a/site/reference/commands.md
+++ b/site/reference/commands.md
@@ -12,7 +12,7 @@ ketch search <query> [flags]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--backend, -b` | `brave` | Search backend: `brave`, `ddg`, `searxng`, `exa` |
+| `--backend, -b` | `brave` | Search backend: `brave`, `ddg`, `searxng`, `exa`, `firecrawl` |
 | `--limit, -l` | `5` | Max number of results |
 | `--scrape` | `false` | Fetch full content from each result |
 | `--minimal` | `false` | One result per line, tab-separated |
@@ -30,6 +30,7 @@ ketch search "rust async" --limit 10
 ketch search "python web scraping" --scrape
 ketch search "query" --backend searxng
 ketch search "query" --backend exa
+ketch search "query" --backend firecrawl
 ketch search "query" --json
 ```
 
@@ -225,7 +226,7 @@ ketch cache clear         # remove all cached pages
 ## ketch doctor
 
 Run live health checks against every surface: search backends
-(brave/ddg/searxng/exa), code backends (grepapp/sourcegraph/github), docs
+(brave/ddg/searxng/exa/firecrawl), code backends (grepapp/sourcegraph/github), docs
 (context7), the configured browser binary, and the page cache. Probes run
 concurrently with a per-check timeout and are read-only (nothing is written
 to the cache).

--- a/skills/ketch/SKILL.md
+++ b/skills/ketch/SKILL.md
@@ -31,7 +31,7 @@ Use only these terms in ketch output.
 | --- | --- |
 | **surface** | One of the five research operations: `search`, `code`, `docs`, `scrape`, `crawl` |
 | **transport** | How a surface is called: the CLI binary (default) or the optional MCP tools |
-| **backend** | The provider behind a surface: brave/ddg/searxng/exa (search), grepapp/sourcegraph/github (code), context7 (docs) |
+| **backend** | The provider behind a surface: brave/ddg/searxng/exa/firecrawl (search), grepapp/sourcegraph/github (code), context7 (docs) |
 | **operator action** | A system-managing or diagnostic command — `config set`, `cache`, `browser install`, background crawls, `doctor` — CLI-only by design |
 | **error prefix** | The stable class on every ketch error: CLI exit codes 2–6, mirrored as the bracketed prefix opening every MCP tool error — `[validation]`, `[not_found]`, `[upstream]`, `[precondition]`, `[cancelled]` |
 | **fan-out** | How many queries are searched and URLs scraped under one plan |

--- a/skills/ketch/references/surfaces.md
+++ b/skills/ketch/references/surfaces.md
@@ -27,7 +27,7 @@ The two transports expose the same options under different spellings. Both direc
 
 ## search
 
-- Backends: `brave` (default when unconfigured; free API key), `ddg` (zero setup; rate-limits readily under fan-out), `searxng` (self-hosted; needs a JSON-enabled instance — see the setup verb), `exa` (zero config).
+- Backends: `brave` (default when unconfigured; free API key), `ddg` (zero setup; rate-limits readily under fan-out), `searxng` (self-hosted; needs a JSON-enabled instance — see the setup verb), `exa` (zero config), `firecrawl` (Firecrawl v2 search API; needs `firecrawl_api_key`).
 - The effective default backend is operator-configured: **omit `backend` to use it**; `ketch config` shows which it is.
 - `--scrape` / `scrape: true` fetches each result's full content — budget it exactly like a scrape (`max_chars`, `trim`).
 - `--minimal` (CLI): one result per line, tab-separated url/title/snippet.
@@ -70,7 +70,7 @@ The two transports expose the same options under different spellings. Both direc
 
 | Surface | Keyless | Keyed | Set with |
 | --- | --- | --- | --- |
-| search | ddg, searxng (self-hosted), exa | brave | `ketch config set brave_api_key <key>` |
+| search | ddg, searxng (self-hosted), exa | brave, firecrawl | `ketch config set brave_api_key <key>` / `ketch config set firecrawl_api_key <key>` |
 | code | grepapp, sourcegraph | github | `gh auth login` / `$GITHUB_TOKEN` / `ketch config set github_token <tok>` |
 | docs | — | context7 (free key) | `ketch config set context7_api_key <key>` |
 
@@ -83,7 +83,7 @@ A missing-key call fails with `[precondition]` / exit 5 and an error message tha
 - File: `~/.config/ketch/config.json`. Flags always override config values.
 - `ketch config` is the one discovery call: effective settings plus `available_backends`, `available_code_backends`, `available_doc_backends`, as JSON. Never probe env vars instead.
 - **Blind spots:** older builds do not report whether search/docs API keys are set (`github_token_source` is the exception; newer builds add key-presence booleans like `brave_api_key_set`), and no build reports reachability. To know a surface works, probe it — `ketch doctor` when available, else the setup verb's probe table.
-- Keys (from README and `ketch config` output): `backend`, `code_backend`, `docs_backend`, `limit`, `searxng_url`, `sourcegraph_url`, `brave_api_key`, `context7_api_key`, `github_token`, `exa_api_key`, `browser`, `cache_ttl`, `url_rewrites`, `spa_markers`.
+- Keys (from README and `ketch config` output): `backend`, `code_backend`, `docs_backend`, `limit`, `searxng_url`, `sourcegraph_url`, `brave_api_key`, `context7_api_key`, `github_token`, `exa_api_key`, `firecrawl_api_key`, `browser`, `cache_ttl`, `url_rewrites`, `spa_markers`.
 - `KETCH_CONFIG` is **not** supported. For test isolation, override `HOME` / `XDG_CONFIG_HOME`.
 
 ## Cache

--- a/skills/ketch/references/verbs/setup.md
+++ b/skills/ketch/references/verbs/setup.md
@@ -64,6 +64,7 @@ On older ketch versions without `doctor`, configured-state detection is imperfec
 
    Right for: self-hosting preference, heavy volume, privacy.
 4. **exa — hosted alternative.** Works with zero config; `exa_api_key` exists for keyed use.
+5. **firecrawl — same provider as scrape/crawl.** Needs a key: `ketch config set firecrawl_api_key <key>` (get one at firecrawl.dev), then `ketch config set backend firecrawl`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **Firecrawl** as a fifth `ketch search` web-search backend, following the same shape as the existing Exa/Brave backends. Firecrawl's pluggable surface in ketch is search — `scrape`/`crawl` are a single built-in HTTP+browser pipeline, not provider-pluggable, so search is the natural, non-awkward home.

- **New backend** `search/firecrawl.go` — calls the Firecrawl v2 search API (`POST https://api.firecrawl.dev/v2/search`) via the shared `httpx.Default()` client, mapping `data.web[]` → `search.Result{Title,URL,Description}`. Uses the REST API directly rather than an SDK, matching how the Brave/SearXNG backends already call thin JSON HTTP (there is no Firecrawl Go SDK; a thin REST call is the idiomatic fit here).
- **Wiring** (every consumer of the search-backend enum): `search.NewFromConfig` switch, `config.Config.FirecrawlAPIKey` + `config.AvailableBackends()`, `ketch config set firecrawl_api_key`, the `ketch config` discovery payload (`firecrawl_api_key_set`), a live `ketch doctor` search-backend probe (`probeFirecrawl`), and the MCP `search` tool schema.
- **Config-first, like the rest of ketch:** the key lives in `~/.config/ketch/config.json` (`ketch config set firecrawl_api_key <key>`), consistent with every other backend — ketch has no `.env` mechanism, so none was added.
- **Docs** updated to match the code: README, CLAUDE.md, AGENTS.md, the VitePress site (backends/commands/configuration/agent-integration + changelog), and the bundled agent skill. Backlinks to https://docs.firecrawl.dev added where backends are described.
- **Tests**: parse / request-shape / limit / empty / invalid-key / server-error for the backend, plus doctor probe no-key/status-matrix tests, mirroring the existing Brave/Exa test suites.

No SDK version delta (REST integration, nothing to bump). Endpoint path/version confirmed current against docs.firecrawl.dev.

## Verification

Ran the repo's own checks locally with go1.25.7 (matching `go.mod`) and golangci-lint v2.5.0 (go1.25-built, to match the repo's `version: "2"` config) — i.e. the exact steps the `.githooks/pre-commit` hook runs.

- **Live Firecrawl request ✅** — built the binary and ran `ketch search "golang context cancellation" -b firecrawl --limit 3 --json` with a real key: returned real web results. `ketch doctor --json` shows `search/firecrawl → ok` with a live `latency_ms`, and a raw `curl` to `/v2/search` returned response-only fields (`creditsUsed`, `id`) confirming a genuine API hit (not a mock/cache).
- **`ketch config` discovery ✅** — `firecrawl_api_key_set` and `firecrawl` in `available_backends` both surface correctly.
- **Build ✅** — `go build ./...`.
- **Tests ✅** — `go test ./...` (full suite, all packages pass), including the new `search`/`doctor` tests.
- **Vet ✅** — `go vet ./...` clean.
- **Lint/format ✅** — `gofmt -l` clean; `golangci-lint run ./...` → `0 issues`. (Adding one `config set` case takes `applyConfigSet` to `gocyclo` complexity 16, one over the repo's threshold of 15. Rather than restructure the unrelated existing cases, the flat key→field dispatch carries a scoped `//nolint:gocyclo` — its complexity is just one arm per config key, not real branching depth.)
