### PR TITLE
feat: add firecrawl_url for self-hosted Firecrawl (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Self-hosted Firecrawl** (#31). `firecrawl_url` (default `https://api.firecrawl.dev`) overrides the Firecrawl API base; ketch appends `/v2/search`. Hosted cloud still requires `firecrawl_api_key`; a non-default base allows keyless self-hosted instances. Wired through config set/discovery, `KETCH_FIRECRAWL_URL`, search `NewFromConfig`, and `ketch doctor`.
+
 ## [0.13.0] - 2026-07-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Use --concurrency N (default 5) to control parallel request limit.
 | `ddg` | Zero config | Rate-limited by DDG currently |
 | `searxng` | Self-hosted instance | Most reliable for heavy use |
 | `exa` | Zero config via hosted MCP; optional `ketch config set exa_api_key <key>` | AI-oriented search with snippets/content from Exa |
-| `firecrawl` | API key: `ketch config set firecrawl_api_key <key>` | Firecrawl v2 search API; same provider as scrape/crawl workflows |
+| `firecrawl` | API key: `ketch config set firecrawl_api_key <key>` (hosted); optional `firecrawl_url` for self-hosted | Firecrawl v2 search API; same provider as scrape/crawl workflows |
 | `keenable` | Zero config (keyless public endpoint); optional `ketch config set keenable_api_key <key>` | Agent-oriented web search over the Keenable index; key lifts the rate limit |
 
 ### Code Backends (ketch code)
@@ -80,6 +80,7 @@ ketch code "http.NewRequestWithContext" --lang go
 ketch code "NewRequestWith.*Context" --regex
 ketch code "rate limit middleware" --lang go -b github --limit 10
 ketch config set sourcegraph_url https://sourcegraph.com  # optional, for self-hosted
+ketch config set firecrawl_url http://localhost:3002      # optional, self-hosted Firecrawl
 ```
 
 ### Docs Backends (ketch docs)

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Precedence is **CLI flag > `KETCH_*` env > config file > built-in default**. Not
 - Invalid env values (e.g. `KETCH_LIMIT=abc`) fail loudly on commands that use config, naming the offending variable; `ketch version` and `ketch config set/path` still work.
 - Secret `KETCH_*` vars are stripped from the environment of spawned subprocesses (headless browser, external PDF converter).
 
-Other configurable keys include per-backend API keys (`brave_api_key`, `brave_api_keys` for multi-key rotation, `exa_api_key`, `firecrawl_api_key`, `keenable_api_key`, `context7_api_key`, `github_token`), `sourcegraph_url`, `cache_ttl`, `url_rewrites` (regex rewrite rules applied before fetch), `spa_markers` (extra JS-shell detection tokens), `cookie_file` (see below), and the optional external PDF converter command/timeout. Multiple keys per provider are picked randomly per request to spread rate limits. See the [config reference](https://1broseidon.github.io/ketch/) for the full list.
+Other configurable keys include per-backend API keys (`brave_api_key`, `brave_api_keys` for multi-key rotation, `exa_api_key`, `firecrawl_api_key`, `keenable_api_key`, `context7_api_key`, `github_token`), `firecrawl_url` / `sourcegraph_url` (self-hosted overrides), `cache_ttl`, `url_rewrites` (regex rewrite rules applied before fetch), `spa_markers` (extra JS-shell detection tokens), `cookie_file` (see below), and the optional external PDF converter command/timeout. Multiple keys per provider are picked randomly per request to spread rate limits. See the [config reference](https://1broseidon.github.io/ketch/) for the full list.
 
 ### Cookies (BYO cookies.txt)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,7 @@ type configInfo struct {
 	ExaAPIKeysCount                    int               `json:"exa_api_keys_count"`
 	FirecrawlAPIKeySet                 bool              `json:"firecrawl_api_key_set"`
 	FirecrawlAPIKeysCount              int               `json:"firecrawl_api_keys_count"`
+	FirecrawlURL                       string            `json:"firecrawl_url"`
 	KeenableAPIKeySet                  bool              `json:"keenable_api_key_set"`
 	KeenableAPIKeysCount               int               `json:"keenable_api_keys_count"`
 	Limit                              int               `json:"limit"`
@@ -115,6 +116,7 @@ func buildConfigInfo(c config.Config, path string) configInfo {
 		ExaAPIKeysCount:                    len(exaKeys),
 		FirecrawlAPIKeySet:                 len(firecrawlKeys) > 0,
 		FirecrawlAPIKeysCount:              len(firecrawlKeys),
+		FirecrawlURL:                       c.EffectiveFirecrawlURL(),
 		KeenableAPIKeySet:                  len(keenableKeys) > 0,
 		KeenableAPIKeysCount:               len(keenableKeys),
 		Limit:                              c.Limit,
@@ -234,6 +236,8 @@ func applyConfigSet(c *config.Config, key, value string) error {
 		c.FirecrawlAPIKey = value
 	case "firecrawl_api_keys":
 		return setAPIKeys(&c.FirecrawlAPIKeys, key, value)
+	case "firecrawl_url":
+		c.FirecrawlURL = value
 	case "keenable_api_key":
 		c.KeenableAPIKey = value
 	case "keenable_api_keys":
@@ -267,7 +271,7 @@ func applyConfigSet(c *config.Config, key, value string) error {
 	case "external_pdf_to_md_converter_timeout_sec":
 		return setExternalPDFConverterTimeout(c, value)
 	default:
-		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, brave_api_keys, exa_api_key, exa_api_keys, firecrawl_api_key, firecrawl_api_keys, keenable_api_key, keenable_api_keys, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers, cookie_file, user_agent, external_pdf_to_md_converter_command, external_pdf_to_md_converter_timeout_sec)", key)
+		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, brave_api_keys, exa_api_key, exa_api_keys, firecrawl_api_key, firecrawl_api_keys, firecrawl_url, keenable_api_key, keenable_api_keys, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers, cookie_file, user_agent, external_pdf_to_md_converter_command, external_pdf_to_md_converter_timeout_sec)", key)
 	}
 	return nil
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -163,6 +163,20 @@ func TestApplyConfigSetURLRewritesValidJSON(t *testing.T) {
 	}
 }
 
+func TestApplyConfigSetFirecrawlURL(t *testing.T) {
+	c := config.Defaults()
+	if err := applyConfigSet(&c, "firecrawl_url", "http://localhost:3002"); err != nil {
+		t.Fatal(err)
+	}
+	if c.FirecrawlURL != "http://localhost:3002" {
+		t.Fatalf("FirecrawlURL = %q", c.FirecrawlURL)
+	}
+	info := buildConfigInfo(c, "/tmp/config.json")
+	if info.FirecrawlURL != "http://localhost:3002" {
+		t.Fatalf("discovery firecrawl_url = %q", info.FirecrawlURL)
+	}
+}
+
 func TestApplyConfigSetURLRewritesInvalidJSON(t *testing.T) {
 	c := config.Defaults()
 	err := applyConfigSet(&c, "url_rewrites", `not json`)

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	ExaAPIKeys                         []string          `json:"exa_api_keys,omitempty"`
 	FirecrawlAPIKey                    string            `json:"firecrawl_api_key,omitempty"`
 	FirecrawlAPIKeys                   []string          `json:"firecrawl_api_keys,omitempty"`
+	FirecrawlURL                       string            `json:"firecrawl_url,omitempty"` // base URL; empty = DefaultFirecrawlURL
 	KeenableAPIKey                     string            `json:"keenable_api_key,omitempty"`
 	KeenableAPIKeys                    []string          `json:"keenable_api_keys,omitempty"`
 	Limit                              int               `json:"limit"`
@@ -105,11 +106,16 @@ func (c Config) ResolveGithubToken() (token, source string) {
 	return "", "none"
 }
 
+// DefaultFirecrawlURL is the hosted Firecrawl API base. Self-hosted
+// instances override it via firecrawl_url (ketch appends /v2/search).
+const DefaultFirecrawlURL = "https://api.firecrawl.dev"
+
 // Defaults returns the built-in default configuration.
 func Defaults() Config {
 	return Config{
 		Backend:                            "brave",
 		SearxngURL:                         "http://localhost:8081",
+		FirecrawlURL:                       DefaultFirecrawlURL,
 		Limit:                              5,
 		CacheTTL:                           "72h",
 		CodeBackend:                        "grepapp",
@@ -117,6 +123,21 @@ func Defaults() Config {
 		SourcegraphURL:                     "https://sourcegraph.com",
 		ExternalPDFToMDConverterTimeoutSec: 300,
 	}
+}
+
+// EffectiveFirecrawlURL returns the Firecrawl API base URL, falling back to
+// DefaultFirecrawlURL when unset.
+func (c Config) EffectiveFirecrawlURL() string {
+	if u := strings.TrimSpace(c.FirecrawlURL); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return DefaultFirecrawlURL
+}
+
+// IsDefaultFirecrawlURL reports whether the effective Firecrawl base is the
+// hosted cloud API (which requires an API key).
+func (c Config) IsDefaultFirecrawlURL() bool {
+	return strings.EqualFold(c.EffectiveFirecrawlURL(), DefaultFirecrawlURL)
 }
 
 // AvailableBackends returns the list of known search backends.

--- a/config/env.go
+++ b/config/env.go
@@ -93,6 +93,7 @@ func envSpecs() []envSpec {
 		keyPoolSpec("firecrawl_api_key",
 			func(c *Config) *string { return &c.FirecrawlAPIKey },
 			func(c *Config) *[]string { return &c.FirecrawlAPIKeys }),
+		stringSpec("firecrawl_url", func(c *Config) *string { return &c.FirecrawlURL }),
 		keyPoolSpec("keenable_api_key",
 			func(c *Config) *string { return &c.KeenableAPIKey },
 			func(c *Config) *[]string { return &c.KeenableAPIKeys }),

--- a/config/firecrawl_url_test.go
+++ b/config/firecrawl_url_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestEffectiveFirecrawlURL(t *testing.T) {
+	d := Defaults()
+	if got := d.EffectiveFirecrawlURL(); got != DefaultFirecrawlURL {
+		t.Fatalf("default = %q, want %q", got, DefaultFirecrawlURL)
+	}
+	if !d.IsDefaultFirecrawlURL() {
+		t.Fatal("Defaults should report hosted Firecrawl URL")
+	}
+
+	d.FirecrawlURL = "http://localhost:3002/"
+	if got := d.EffectiveFirecrawlURL(); got != "http://localhost:3002" {
+		t.Fatalf("trimmed = %q", got)
+	}
+	if d.IsDefaultFirecrawlURL() {
+		t.Fatal("custom URL should not be treated as hosted default")
+	}
+
+	d.FirecrawlURL = "  "
+	if got := d.EffectiveFirecrawlURL(); got != DefaultFirecrawlURL {
+		t.Fatalf("blank falls back = %q", got)
+	}
+}

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -108,6 +108,7 @@ func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 	keenableKeys := cfg.KeenableKeys()
 	c7Key := cfg.Context7APIKey
 	searxngURL := cfg.SearxngURL
+	firecrawlURL := cfg.EffectiveFirecrawlURL()
 	sourcegraphURL := cfg.SourcegraphURL
 	browser := cfg.Browser
 	cookieFile := cfg.CookieFile
@@ -131,8 +132,9 @@ func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 			})
 		}},
 		{"search", "firecrawl", cfg.Backend == "firecrawl" || len(firecrawlKeys) > 0, func(ctx context.Context) (Status, string) {
+			endpoint := firecrawlSearchURL(firecrawlURL)
 			return probeKeyPool(firecrawlKeys, func(key string) (Status, string) {
-				return probeFirecrawl(ctx, client, firecrawlSearch, key)
+				return probeFirecrawl(ctx, client, endpoint, key)
 			})
 		}},
 		{"search", "keenable", cfg.Backend == "keenable" || len(keenableKeys) > 0, func(ctx context.Context) (Status, string) {

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -118,12 +118,31 @@ func TestProbeFirecrawlNoKey(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	status, detail := probeFirecrawl(testCtx(t), ts.Client(), ts.URL, "")
+	status, detail := probeFirecrawl(testCtx(t), ts.Client(), firecrawlSearchURL(config.DefaultFirecrawlURL), "")
 	if status != StatusNoKey {
 		t.Fatalf("status = %q, want no_key", status)
 	}
 	if !strings.Contains(detail, "firecrawl_api_key") {
 		t.Errorf("detail %q should carry the config hint", detail)
+	}
+}
+
+func TestProbeFirecrawlSelfHostedNoKey(t *testing.T) {
+	var sawAuth bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuth = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	status, _ := probeFirecrawl(testCtx(t), ts.Client(), ts.URL, "")
+	if status != StatusOK {
+		t.Fatalf("status = %q, want ok", status)
+	}
+	if sawAuth {
+		t.Fatal("self-hosted keyless probe must omit Authorization")
 	}
 }
 

--- a/doctor/probes.go
+++ b/doctor/probes.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/1broseidon/ketch/cache"
+	"github.com/1broseidon/ketch/config"
 	"github.com/1broseidon/ketch/cookies"
 	"github.com/1broseidon/ketch/scrape"
 )
@@ -28,7 +29,6 @@ const (
 	ddgEndpoint      = "https://html.duckduckgo.com/html/"
 	grepAppEndpoint  = "https://mcp.grep.app"
 	exaMCPEndpoint   = "https://mcp.exa.ai/mcp"
-	firecrawlSearch  = "https://api.firecrawl.dev/v2/search"
 	keenableEndpoint = "https://api.keenable.ai"
 	githubAPIBase    = "https://api.github.com"
 	context7APIBase  = "https://context7.com"
@@ -159,18 +159,36 @@ func probeBrave(ctx context.Context, client *http.Client, endpoint, apiKey strin
 	}
 }
 
+// firecrawlSearchURL joins a Firecrawl API base with /v2/search. Empty base
+// falls back to the hosted default. Mirrors search.firecrawlSearchURL.
+func firecrawlSearchURL(base string) string {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" {
+		base = config.DefaultFirecrawlURL
+	}
+	return base + "/v2/search"
+}
+
 // probeFirecrawl checks the Firecrawl v2 search API with a minimal one-result
-// query. Firecrawl requires an API key, so a missing key is a clean no_key.
+// query. The hosted cloud API requires a key (missing key → no_key without a
+// network call). Self-hosted instances often run without auth, so an empty key
+// against a non-default base probes without an Authorization header.
 func probeFirecrawl(ctx context.Context, client *http.Client, endpoint, apiKey string) (Status, string) {
-	if apiKey == "" {
-		return StatusNoKey, "API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)"
+	key := strings.TrimSpace(apiKey)
+	if key == "" {
+		cloud := firecrawlSearchURL(config.DefaultFirecrawlURL)
+		if strings.EqualFold(strings.TrimRight(endpoint, "/"), strings.TrimRight(cloud, "/")) {
+			return StatusNoKey, "API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)"
+		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(`{"query":"ketch","limit":1}`))
 	if err != nil {
 		return StatusUnreachable, probeErrDetail(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -182,6 +200,9 @@ func probeFirecrawl(ctx context.Context, client *http.Client, endpoint, apiKey s
 	case http.StatusOK:
 		return StatusOK, ""
 	case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired:
+		if key == "" {
+			return StatusMisconfigured, "instance requires an API key (ketch config set firecrawl_api_key <key>)"
+		}
 		return StatusMisconfigured, "API key rejected (ketch config set firecrawl_api_key <key>)"
 	case http.StatusTooManyRequests:
 		return StatusOK, "reachable, key accepted (rate limited)"

--- a/search/config.go
+++ b/search/config.go
@@ -37,10 +37,12 @@ func NewFromConfig(cfg *config.Config, backend, searxngURL string) (Searcher, er
 		return newEXAWithKeys(cfg.ExaKeys()), nil
 	case "firecrawl":
 		keys := cfg.FirecrawlKeys()
-		if len(keys) == 0 {
+		// Hosted Firecrawl requires a key; self-hosted instances often run
+		// without auth, so a custom firecrawl_url may omit the key.
+		if len(keys) == 0 && cfg.IsDefaultFirecrawlURL() {
 			return nil, fmt.Errorf("firecrawl: API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)")
 		}
-		return newFirecrawlWithKeys(keys), nil
+		return newFirecrawlWithKeys(keys, cfg.EffectiveFirecrawlURL()), nil
 	case "keenable":
 		return newKeenableWithKeys(cfg.KeenableKeys()), nil
 	default:

--- a/search/config_test.go
+++ b/search/config_test.go
@@ -90,3 +90,63 @@ func TestExportedBackendConstructorsKeepSingleKeyCompatibility(t *testing.T) {
 		}
 	}
 }
+
+func TestNewFromConfigFirecrawlURL(t *testing.T) {
+	t.Run("cloud requires key", func(t *testing.T) {
+		cfg := config.Defaults()
+		if _, err := NewFromConfig(&cfg, "firecrawl", ""); err == nil {
+			t.Fatal("expected missing-key error for hosted Firecrawl")
+		}
+	})
+
+	t.Run("self-hosted allows empty key", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FirecrawlURL = "http://localhost:3002"
+		searcher, err := NewFromConfig(&cfg, "firecrawl", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		backend, ok := searcher.(*Firecrawl)
+		if !ok {
+			t.Fatalf("unexpected type %T", searcher)
+		}
+		if backend.keys.size() != 0 {
+			t.Fatalf("keys = %d, want 0", backend.keys.size())
+		}
+		if got := backend.endpoint; got != "http://localhost:3002/v2/search" {
+			t.Fatalf("endpoint = %q, want local /v2/search", got)
+		}
+	})
+
+	t.Run("custom base with key", func(t *testing.T) {
+		cfg := config.Defaults()
+		cfg.FirecrawlURL = "https://fc.example.com/"
+		cfg.FirecrawlAPIKey = "k"
+		searcher, err := NewFromConfig(&cfg, "firecrawl", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		backend := searcher.(*Firecrawl)
+		if got := backend.endpoint; got != "https://fc.example.com/v2/search" {
+			t.Fatalf("endpoint = %q", got)
+		}
+	})
+}
+
+func TestFirecrawlSearchURL(t *testing.T) {
+	tests := []struct {
+		base string
+		want string
+	}{
+		{"", config.DefaultFirecrawlURL + "/v2/search"},
+		{"https://api.firecrawl.dev", config.DefaultFirecrawlURL + "/v2/search"},
+		{"https://api.firecrawl.dev/", config.DefaultFirecrawlURL + "/v2/search"},
+		{"http://localhost:3002", "http://localhost:3002/v2/search"},
+		{"  http://fc.local/  ", "http://fc.local/v2/search"},
+	}
+	for _, tc := range tests {
+		if got := firecrawlSearchURL(tc.base); got != tc.want {
+			t.Errorf("firecrawlSearchURL(%q) = %q, want %q", tc.base, got, tc.want)
+		}
+	}
+}

--- a/search/firecrawl.go
+++ b/search/firecrawl.go
@@ -9,26 +9,38 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/1broseidon/ketch/config"
 	"github.com/1broseidon/ketch/httpx"
 )
 
-// firecrawlSearchEndpoint is the Firecrawl v2 search API. See
-// https://docs.firecrawl.dev/api-reference/endpoint/search.
-const firecrawlSearchEndpoint = "https://api.firecrawl.dev/v2/search"
-
 // Firecrawl searches the web via the Firecrawl v2 search API.
 type Firecrawl struct {
-	keys   keyPool
-	client *http.Client
+	keys     keyPool
+	client   *http.Client
+	endpoint string // full POST URL (base + /v2/search)
 }
 
-// NewFirecrawl creates a new Firecrawl search backend.
+// NewFirecrawl creates a new Firecrawl search backend against the hosted API.
 func NewFirecrawl(apiKey string) *Firecrawl {
-	return newFirecrawlWithKeys([]string{apiKey})
+	return newFirecrawlWithKeys([]string{apiKey}, config.DefaultFirecrawlURL)
 }
 
-func newFirecrawlWithKeys(keys []string) *Firecrawl {
-	return &Firecrawl{keys: newKeyPool(keys), client: httpx.Default()}
+func newFirecrawlWithKeys(keys []string, baseURL string) *Firecrawl {
+	return &Firecrawl{
+		keys:     newKeyPool(keys),
+		client:   httpx.Default(),
+		endpoint: firecrawlSearchURL(baseURL),
+	}
+}
+
+// firecrawlSearchURL joins a Firecrawl API base with the v2 search path.
+// Trailing slashes on base are stripped; an empty base uses the hosted default.
+func firecrawlSearchURL(base string) string {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" {
+		base = config.DefaultFirecrawlURL
+	}
+	return base + "/v2/search"
 }
 
 type firecrawlRequest struct {
@@ -117,12 +129,18 @@ func (f *Firecrawl) Search(ctx context.Context, query string, limit int) ([]Resu
 }
 
 func (f *Firecrawl) request(ctx context.Context, body []byte, key string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, firecrawlSearchEndpoint, bytes.NewReader(body))
+	endpoint := f.endpoint
+	if endpoint == "" {
+		endpoint = firecrawlSearchURL("")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+key)
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
 	resp, err := f.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("firecrawl request failed: %w", err)

--- a/search/search_feature_test.go
+++ b/search/search_feature_test.go
@@ -564,6 +564,34 @@ func TestFeatureFirecrawlRequestShape(t *testing.T) {
 	}
 }
 
+func TestFeatureFirecrawlSelfHostedEndpoint(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"web":[{"url":"https://example.com","title":"Ex","description":"d"}]}}`)
+	}))
+	defer server.Close()
+
+	f := newFirecrawlWithKeys(nil, server.URL)
+	results, err := f.Search(context.Background(), "q", 1)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if gotPath != "/v2/search" {
+		t.Errorf("path = %q, want /v2/search", gotPath)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want empty for keyless self-host", gotAuth)
+	}
+}
+
 func TestFeatureFirecrawlLimitRespected(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/site/guide/agent-integration.md
+++ b/site/guide/agent-integration.md
@@ -84,6 +84,7 @@ ketch scrape https://help.example.com/s/article/1234
   "exa_api_keys_count": 0,
   "firecrawl_api_key_set": false,
   "firecrawl_api_keys_count": 0,
+  "firecrawl_url": "https://api.firecrawl.dev",
   "keenable_api_key_set": false,
   "keenable_api_keys_count": 0,
   "limit": 5,

--- a/site/guide/configuration.md
+++ b/site/guide/configuration.md
@@ -25,6 +25,7 @@ The discovery payload:
   "exa_api_keys_count": 0,
   "firecrawl_api_key_set": false,
   "firecrawl_api_keys_count": 0,
+  "firecrawl_url": "https://api.firecrawl.dev",
   "keenable_api_key_set": false,
   "keenable_api_keys_count": 0,
   "limit": 5,
@@ -62,6 +63,7 @@ ketch config set brave_api_keys '["BSA-key-1","BSA-key-2"]'   # multi-key pool (
 ketch config set searxng_url http://my-searxng:8080
 ketch config set exa_api_key exa...
 ketch config set firecrawl_api_key fc-...
+ketch config set firecrawl_url http://localhost:3002
 ketch config set keenable_api_key keen_...
 ketch config set limit 10
 ketch config set cache_ttl 4h
@@ -86,8 +88,9 @@ ketch config set github_token ghp_...
 | `brave_api_keys` | — | Additional Brave keys (JSON array) — see [multiple keys](#multiple-api-keys-per-provider) |
 | `exa_api_key` | — | Optional Exa API key for authenticated hosted MCP usage |
 | `exa_api_keys` | — | Additional Exa keys (JSON array) |
-| `firecrawl_api_key` | — | [Firecrawl](https://docs.firecrawl.dev) API key (required for `-b firecrawl`) |
+| `firecrawl_api_key` | — | [Firecrawl](https://docs.firecrawl.dev) API key (required for hosted `-b firecrawl`; optional for self-hosted) |
 | `firecrawl_api_keys` | — | Additional Firecrawl keys (JSON array) |
+| `firecrawl_url` | `https://api.firecrawl.dev` | Firecrawl API base URL (self-hosted override; ketch appends `/v2/search`) |
 | `keenable_api_key` | — | Optional Keenable API key; keyless by default, a key lifts the rate limit ([console](https://keenable.ai/console)) |
 | `keenable_api_keys` | — | Additional Keenable keys (JSON array) |
 | `searxng_url` | `http://localhost:8081` | SearXNG instance URL |

--- a/site/reference/backends.md
+++ b/site/reference/backends.md
@@ -65,13 +65,24 @@ ketch config set backend exa
 
 ## Firecrawl
 
-Web search via the [Firecrawl](https://firecrawl.dev) v2 [search API](https://docs.firecrawl.dev/api-reference/endpoint/search) — proper JSON API, no scraping. Requires an API key.
+Web search via the [Firecrawl](https://firecrawl.dev) v2 [search API](https://docs.firecrawl.dev/api-reference/endpoint/search) — proper JSON API, no scraping. The hosted cloud API requires an API key; self-hosted instances often run without one.
 
-**Setup:**
+**Setup (hosted):**
 
 1. Get an API key at [firecrawl.dev](https://firecrawl.dev)
 2. Set it: `ketch config set firecrawl_api_key <your-key>`
 3. Make it the default: `ketch config set backend firecrawl`
+
+**Setup (self-hosted):**
+
+```sh
+ketch config set firecrawl_url http://localhost:3002
+ketch config set backend firecrawl
+# optional if your instance requires auth:
+# ketch config set firecrawl_api_key <your-key>
+```
+
+`firecrawl_url` is the API base (ketch appends `/v2/search`). Default is `https://api.firecrawl.dev`.
 
 **Recommended for:** operators already using Firecrawl for scraping who want a single provider for both search and page extraction. Pair with `--scrape` to fetch full content per result.
 

--- a/skills/ketch/references/surfaces.md
+++ b/skills/ketch/references/surfaces.md
@@ -28,7 +28,7 @@ The two transports expose the same options under different spellings. Both direc
 
 ## search
 
-- Backends: `brave` (default when unconfigured; free API key), `ddg` (zero setup; rate-limits readily under fan-out), `searxng` (self-hosted; needs a JSON-enabled instance — see the setup verb), `exa` (zero config), `firecrawl` (Firecrawl v2 search API; needs `firecrawl_api_key`), `keenable` (keyless by default; optional `keenable_api_key` lifts the rate limit).
+- Backends: `brave` (default when unconfigured; free API key), `ddg` (zero setup; rate-limits readily under fan-out), `searxng` (self-hosted; needs a JSON-enabled instance — see the setup verb), `exa` (zero config), `firecrawl` (Firecrawl v2 search API; hosted needs `firecrawl_api_key`, self-hosted via `firecrawl_url`), `keenable` (keyless by default; optional `keenable_api_key` lifts the rate limit).
 - The effective default backend is operator-configured: **omit `backend` to use it**; `ketch config` shows which it is.
 - `--scrape` / `scrape: true` fetches each result's full content — budget it exactly like a scrape (`max_chars`, `trim`).
 - `--minimal` (CLI): one result per line, tab-separated url/title/snippet (a 4th backends column is appended under `--multi` for plain search; `--scrape --minimal` keeps 3 columns).
@@ -86,7 +86,7 @@ A missing-key call fails with `[precondition]` / exit 5 and an error message tha
 - File: `~/.config/ketch/config.json`. Flags always override config values.
 - `ketch config` is the one discovery call: effective settings plus `available_backends`, `available_code_backends`, `available_doc_backends`, as JSON. Never probe env vars instead.
 - **Blind spots:** older builds do not report whether search/docs API keys are set (`github_token_source` is the exception; newer builds add key-presence booleans like `brave_api_key_set`), and no build reports reachability. To know a surface works, probe it — `ketch doctor` when available, else the setup verb's probe table.
-- Keys (from README and `ketch config` output): `backend`, `code_backend`, `docs_backend`, `limit`, `searxng_url`, `sourcegraph_url`, `brave_api_key`, `context7_api_key`, `github_token`, `exa_api_key`, `firecrawl_api_key`, `keenable_api_key`, `browser`, `cache_ttl`, `url_rewrites`, `spa_markers`.
+- Keys (from README and `ketch config` output): `backend`, `code_backend`, `docs_backend`, `limit`, `searxng_url`, `sourcegraph_url`, `brave_api_key`, `context7_api_key`, `github_token`, `exa_api_key`, `firecrawl_api_key`, `firecrawl_url`, `keenable_api_key`, `browser`, `cache_ttl`, `url_rewrites`, `spa_markers`.
 - `KETCH_CONFIG` is **not** supported. For test isolation, override `HOME` / `XDG_CONFIG_HOME`.
 
 ## Cache

--- a/skills/ketch/references/verbs/setup.md
+++ b/skills/ketch/references/verbs/setup.md
@@ -64,7 +64,7 @@ On older ketch versions without `doctor`, configured-state detection is imperfec
 
    Right for: self-hosting preference, heavy volume, privacy.
 4. **exa — hosted alternative.** Works with zero config; `exa_api_key` exists for keyed use.
-5. **firecrawl — same provider as scrape/crawl.** Needs a key: `ketch config set firecrawl_api_key <key>` (get one at firecrawl.dev), then `ketch config set backend firecrawl`.
+5. **firecrawl — same provider as scrape/crawl.** Hosted needs a key: `ketch config set firecrawl_api_key <key>` (get one at firecrawl.dev), then `ketch config set backend firecrawl`. Self-hosted: `ketch config set firecrawl_url http://localhost:3002` (key optional if your instance skips auth).
 6. **keenable — keyless by default.** Works with no key against the public endpoint (rate-limited); an optional `ketch config set keenable_api_key <key>` lifts the cap. Select with `ketch config set backend keenable`.
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #31.

Adds a `firecrawl_url` config key so the firecrawl search backend can target a self-hosted Firecrawl instance instead of the hard-coded cloud endpoint.

### Behavior
- `firecrawl_url` is the **API base** (default `https://api.firecrawl.dev`); ketch appends `/v2/search`
- Hosted cloud still requires `firecrawl_api_key`
- A non-default base allows keyless self-hosted instances (Authorization omitted when no key)
- Wired through `ketch config set` / discovery, `KETCH_FIRECRAWL_URL`, `search.NewFromConfig`, and `ketch doctor`

### Usage
```sh
ketch config set firecrawl_url http://localhost:3002
ketch config set backend firecrawl
# optional if your instance requires auth:
# ketch config set firecrawl_api_key <key>
```

### Tests
`go test ./...` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb0b8-e0fe-74b0-97a8-f54b07796f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb0b8-e0fe-74b0-97a8-f54b07796f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

