### PR TITLE
fix: flatten Parallel result titles and descriptions onto one line

### DIFF
--- a/search/parallel.go
+++ b/search/parallel.go
@@ -143,7 +143,7 @@ func appendParallelResults(results []Result, text string, limit int) ([]Result, 
 			description = boundedParallelDescription(excerpts[0])
 		}
 		results = append(results, Result{
-			Title:       raw.Title,
+			Title:       collapseParallelWhitespace(raw.Title),
 			URL:         raw.URL,
 			Description: description,
 			Content:     strings.Join(excerpts, "\n"),
@@ -152,12 +152,22 @@ func appendParallelResults(results []Result, text string, limit int) ([]Result, 
 	return results, nil
 }
 
+// collapseParallelWhitespace flattens a value onto a single line, collapsing
+// every run of whitespace to one space. Parallel returns extracted page text,
+// so titles and excerpts can carry newlines and indentation. Results are
+// printed one per line — `--minimal` emits "url\ttitle\tdescription\n" — so an
+// embedded newline or tab in either field would break that row contract.
+func collapseParallelWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
 func boundedParallelDescription(excerpt string) string {
+	excerpt = collapseParallelWhitespace(excerpt)
 	runes := []rune(excerpt)
 	if len(runes) <= parallelDescriptionMaxRunes {
 		return excerpt
 	}
-	return string(runes[:parallelDescriptionMaxRunes-1]) + "…"
+	return strings.TrimSpace(string(runes[:parallelDescriptionMaxRunes-1])) + "…"
 }
 
 func nonEmptyStrings(values []string) []string {

--- a/search/parallel_test.go
+++ b/search/parallel_test.go
@@ -119,6 +119,49 @@ func TestParallelSearchBoundsDescriptionWithoutTruncatingContent(t *testing.T) {
 	}
 }
 
+func TestParallelSearchCollapsesWhitespaceInTitleAndDescription(t *testing.T) {
+	t.Parallel()
+	rawTitle := "\n         How to Handle Errors in Go\n    "
+	rawExcerpt := "First line.\n\n* bullet\t\ttabbed\n  indented tail"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeParallelResponse(t, w, fmt.Sprintf(
+			`{"results":[{"url":"https://example.com","title":%q,"excerpts":[%q]}]}`,
+			rawTitle, rawExcerpt,
+		))
+	}))
+	defer server.Close()
+
+	backend := &Parallel{client: server.Client(), endpoint: server.URL}
+	results, err := backend.Search(context.Background(), "q", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// --minimal prints "url\ttitle\tdescription\n", so neither field may carry
+	// a newline or tab without breaking the one-result-per-line contract.
+	for _, field := range []struct{ name, value string }{
+		{"title", results[0].Title},
+		{"description", results[0].Description},
+	} {
+		if strings.ContainsAny(field.value, "\n\t") {
+			t.Errorf("%s = %q, want no newline or tab", field.name, field.value)
+		}
+		if field.value != strings.TrimSpace(field.value) {
+			t.Errorf("%s = %q, want no leading/trailing space", field.name, field.value)
+		}
+	}
+	if want := "How to Handle Errors in Go"; results[0].Title != want {
+		t.Errorf("title = %q, want %q", results[0].Title, want)
+	}
+	if want := "First line. * bullet tabbed indented tail"; results[0].Description != want {
+		t.Errorf("description = %q, want %q", results[0].Description, want)
+	}
+	// Content keeps the full, unflattened excerpt text.
+	if results[0].Content != rawExcerpt {
+		t.Errorf("content = %q, want the raw excerpt preserved", results[0].Content)
+	}
+}
+
 func TestParallelSearchZeroLimitSkipsRequest(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {


### PR DESCRIPTION
Follow-up to #33.

## Problem

Parallel returns extracted page text, so titles and excerpts can carry
newlines, tabs, and indentation. `boundedParallelDescription` caps the
description's **length** (300 runes) but not its **shape**, and `Title` was
passed through raw.

Search results are printed one per line — `--minimal` emits
`"url\ttitle\tdescription\n"` ([`cmd/search.go`](cmd/search.go)) — so an
embedded newline in either field silently breaks the one-result-per-line
contract that scripted and agent callers parse.

Measured against the live backend before this change:

```
$ ketch search "go error handling" -b parallel --minimal --limit 3
# 30 lines emitted for 3 results
```

Sampled queries returned 2–4 of 5 descriptions containing newlines, plus
intermittently dirty titles such as:

```
"\n         How to Handle Errors in Go\n    "
```

## Fix

Collapse every run of whitespace to a single space in both `Title` and
`Description` before bounding. `Content` is untouched and still keeps the
complete, unflattened excerpt text.

After:

```
$ ketch search "go error handling patterns" -b parallel --minimal --limit 5
# 5 lines for 5 results
```

This is scoped to the Parallel backend on purpose — other providers return
short, single-line snippets natively and need no normalization.

## Verification

- New test asserts neither field contains a newline/tab or leading/trailing
  space, and that `Content` keeps the raw excerpt.
- `make build && make lint && make test` all pass (lint: 0 issues).
- Confirmed against the live API: line count now equals result count, zero
  dirty titles/descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)