### PR TITLE
feat(search): add Synthetic (synthetic.new) backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 .familiar/
 artifacts/
 specs/
+vendor/

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,6 +38,8 @@ type configInfo struct {
 	TavilyAPIKeysCount                 int               `json:"tavily_api_keys_count"`
 	SerpBaseAPIKeySet                  bool              `json:"serpbase_api_key_set"`
 	SerpBaseAPIKeysCount               int               `json:"serpbase_api_keys_count"`
+	SyntheticAPIKeySet                 bool              `json:"synthetic_api_key_set"`
+	SyntheticAPIKeysCount              int               `json:"synthetic_api_keys_count"`
 	Limit                              int               `json:"limit"`
 	CacheTTL                           string            `json:"cache_ttl"`
 	Browser                            string            `json:"browser,omitempty"`
@@ -112,6 +114,7 @@ func buildConfigInfo(c config.Config, path string) configInfo {
 	keenableKeys := c.KeenableKeys()
 	tavilyKeys := c.TavilyKeys()
 	serpbaseKeys := c.SerpBaseKeys()
+	syntheticKeys := c.SyntheticKeys()
 	return configInfo{
 		ConfigPath:                         path,
 		Backend:                            c.Backend,
@@ -129,6 +132,8 @@ func buildConfigInfo(c config.Config, path string) configInfo {
 		TavilyAPIKeysCount:                 len(tavilyKeys),
 		SerpBaseAPIKeySet:                  len(serpbaseKeys) > 0,
 		SerpBaseAPIKeysCount:               len(serpbaseKeys),
+		SyntheticAPIKeySet:                 len(syntheticKeys) > 0,
+		SyntheticAPIKeysCount:              len(syntheticKeys),
 		Limit:                              c.Limit,
 		CacheTTL:                           c.CacheTTL,
 		Browser:                            c.Browser,
@@ -212,6 +217,8 @@ func configSecretCount(c config.Config, key string) (int, string, bool) {
 		return len(c.TavilyKeys()), "key", true
 	case "serpbase_api_key", "serpbase_api_keys":
 		return len(c.SerpBaseKeys()), "key", true
+	case "synthetic_api_key", "synthetic_api_keys":
+		return len(c.SyntheticKeys()), "key", true
 	case "context7_api_key":
 		return boolCount(c.Context7APIKey != ""), "key", true
 	case "github_token":
@@ -264,6 +271,10 @@ func applyConfigSet(c *config.Config, key, value string) error {
 		c.SerpBaseAPIKey = value
 	case "serpbase_api_keys":
 		return setAPIKeys(&c.SerpBaseAPIKeys, key, value)
+	case "synthetic_api_key":
+		c.SyntheticAPIKey = value
+	case "synthetic_api_keys":
+		return setAPIKeys(&c.SyntheticAPIKeys, key, value)
 	case "limit":
 		return setLimit(c, value)
 	case "cache_ttl":
@@ -293,7 +304,7 @@ func applyConfigSet(c *config.Config, key, value string) error {
 	case "external_pdf_to_md_converter_timeout_sec":
 		return setExternalPDFConverterTimeout(c, value)
 	default:
-		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, brave_api_keys, exa_api_key, exa_api_keys, firecrawl_api_key, firecrawl_api_keys, firecrawl_url, keenable_api_key, keenable_api_keys, tavily_api_key, tavily_api_keys, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers, cookie_file, user_agent, external_pdf_to_md_converter_command, external_pdf_to_md_converter_timeout_sec)", key)
+		return exitErrf(ExitValidation, "unknown key: %s (valid: backend, searxng_url, brave_api_key, brave_api_keys, exa_api_key, exa_api_keys, firecrawl_api_key, firecrawl_api_keys, firecrawl_url, keenable_api_key, keenable_api_keys, tavily_api_key, tavily_api_keys, serpbase_api_key, serpbase_api_keys, synthetic_api_key, synthetic_api_keys, limit, cache_ttl, browser, code_backend, docs_backend, context7_api_key, sourcegraph_url, github_token, url_rewrites, spa_markers, cookie_file, user_agent, external_pdf_to_md_converter_command, external_pdf_to_md_converter_timeout_sec)", key)
 	}
 	return nil
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -14,7 +14,7 @@ var doctorCmd = &cobra.Command{
 	Use:   "doctor",
 	Short: "Check the health of every backend, the browser, and the cache",
 	Long: `Run cheap live health checks against every ketch surface: search backends
-(brave/ddg/searxng/exa/firecrawl/keenable/tavily/parallel/serpbase), code backends
+(brave/ddg/searxng/exa/firecrawl/keenable/tavily/parallel/serpbase/synthetic), code backends
 (grepapp/sourcegraph/github), docs (context7), the configured browser binary,
 and the page cache.
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -18,7 +18,7 @@ import (
 var searchCmd = &cobra.Command{
 	Use:   "search <query>",
 	Short: "Search the web and return results",
-	Long: `Search the web using Brave, DuckDuckGo, SearXNG, Exa, Firecrawl, Keenable, Tavily, Parallel, or SerpBase (default: the configured backend; brave if unset).
+	Long: `Search the web using Brave, DuckDuckGo, SearXNG, Exa, Firecrawl, Keenable, Tavily, Parallel, SerpBase, or Synthetic (default: the configured backend; brave if unset).
 
 Add --scrape to fetch and extract full content from results. Use --multi to query and rank-fuse several providers, or --random to shuffle providers and stop at the first successful response. --multi, --random, and --backend are mutually exclusive.`,
 	Args: exitArgs(cobra.MinimumNArgs(1)),

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -179,7 +179,7 @@ func TestLooksLikeBackendList(t *testing.T) {
 	}{
 		{"brave,exa", true},
 		{"brave, exa", true},
-		{"brave,ddg,searxng,exa,firecrawl,keenable,tavily,parallel,serpbase", true},
+		{"brave,ddg,searxng,exa,firecrawl,keenable,tavily,parallel,serpbase,synthetic", true},
 		{"brave", false},             // single name: no comma, plausible query
 		{"brave,notabackend", false}, // unknown member: real query
 		{"go generics, explained", false},

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	TavilyAPIKeys                      []string          `json:"tavily_api_keys,omitempty"`
 	SerpBaseAPIKey                     string            `json:"serpbase_api_key,omitempty"`
 	SerpBaseAPIKeys                    []string          `json:"serpbase_api_keys,omitempty"`
+	SyntheticAPIKey                    string            `json:"synthetic_api_key,omitempty"`
+	SyntheticAPIKeys                   []string          `json:"synthetic_api_keys,omitempty"`
 	Limit                              int               `json:"limit"`
 	CacheTTL                           string            `json:"cache_ttl"`
 	Browser                            string            `json:"browser,omitempty"` // "chrome", "chromium", or absolute path; empty = disabled
@@ -84,6 +86,11 @@ func (c Config) TavilyKeys() []string { return mergeKeys(c.TavilyAPIKey, c.Tavil
 
 // SerpBaseKeys returns an immutable copy of the effective SerpBase API key pool.
 func (c Config) SerpBaseKeys() []string { return mergeKeys(c.SerpBaseAPIKey, c.SerpBaseAPIKeys) }
+
+// SyntheticKeys returns an immutable copy of the effective Synthetic API key pool.
+func (c Config) SyntheticKeys() []string {
+	return mergeKeys(c.SyntheticAPIKey, c.SyntheticAPIKeys)
+}
 
 // ResolveGithubToken returns a token and the source it came from, walking the
 // resolution chain: $KETCH_GITHUB_TOKEN → explicit config → $GITHUB_TOKEN →
@@ -177,7 +184,7 @@ func FirecrawlSearchURL(base string) string {
 
 // AvailableBackends returns the list of known search backends.
 func AvailableBackends() []string {
-	return []string{"brave", "ddg", "searxng", "exa", "firecrawl", "keenable", "tavily", "parallel", "serpbase"}
+	return []string{"brave", "ddg", "searxng", "exa", "firecrawl", "keenable", "tavily", "parallel", "serpbase", "synthetic"}
 }
 
 // AvailableCodeBackends returns the list of known code search backends.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ func TestParallelBackendIsAppendedWithoutChangingDefault(t *testing.T) {
 	if got := Defaults().Backend; got != "brave" {
 		t.Fatalf("default backend = %q, want brave", got)
 	}
-	want := []string{"brave", "ddg", "searxng", "exa", "firecrawl", "keenable", "tavily", "parallel", "serpbase"}
+	want := []string{"brave", "ddg", "searxng", "exa", "firecrawl", "keenable", "tavily", "parallel", "serpbase", "synthetic"}
 	if got := AvailableBackends(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("available backends = %v, want %v", got, want)
 	}

--- a/config/env.go
+++ b/config/env.go
@@ -103,6 +103,9 @@ func envSpecs() []envSpec {
 		keyPoolSpec("serpbase_api_key",
 			func(c *Config) *string { return &c.SerpBaseAPIKey },
 			func(c *Config) *[]string { return &c.SerpBaseAPIKeys }),
+		keyPoolSpec("synthetic_api_key",
+			func(c *Config) *string { return &c.SyntheticAPIKey },
+			func(c *Config) *[]string { return &c.SyntheticAPIKeys }),
 		{
 			key:  "limit",
 			prev: func(c *Config) string { return strconv.Itoa(c.Limit) },

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -124,6 +124,7 @@ func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 	keenableKeys := cfg.KeenableKeys()
 	tavilyKeys := cfg.TavilyKeys()
 	serpbaseKeys := cfg.SerpBaseKeys()
+	syntheticKeys := cfg.SyntheticKeys()
 	c7Key := cfg.Context7APIKey
 	searxngURL := cfg.SearxngURL
 	firecrawlURL := cfg.EffectiveFirecrawlURL()
@@ -171,6 +172,11 @@ func buildSpecs(cfg *config.Config, client *http.Client) []spec {
 		{"search", "serpbase", cfg.Backend == "serpbase" || len(serpbaseKeys) > 0, func(ctx context.Context) (Status, string) {
 			return probeKeyPool(serpbaseKeys, func(key string) (Status, string) {
 				return probeSerpBase(ctx, client, serpbaseEndpoint, key)
+			})
+		}},
+		{"search", "synthetic", cfg.Backend == "synthetic" || len(syntheticKeys) > 0, func(ctx context.Context) (Status, string) {
+			return probeKeyPool(syntheticKeys, func(key string) (Status, string) {
+				return probeSynthetic(ctx, client, syntheticEndpoint, key)
 			})
 		}},
 		{"code", "grepapp", cfg.CodeBackend == "grepapp", func(ctx context.Context) (Status, string) {

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -496,6 +496,62 @@ func TestProbeSerpBaseStatuses(t *testing.T) {
 	}
 }
 
+// --- synthetic ---
+
+func TestProbeSyntheticNoKey(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("no-key probe must not hit the network")
+	}))
+	defer ts.Close()
+
+	status, detail := probeSynthetic(testCtx(t), ts.Client(), ts.URL, "")
+	if status != StatusNoKey {
+		t.Fatalf("status = %q, want no_key", status)
+	}
+	if !strings.Contains(detail, "synthetic_api_key") {
+		t.Errorf("detail %q should name synthetic_api_key", detail)
+	}
+}
+
+func TestProbeSyntheticStatuses(t *testing.T) {
+	cases := []struct {
+		name   string
+		code   int
+		want   Status
+		detail string
+	}{
+		{"ok", http.StatusOK, StatusOK, ""},
+		{"401", http.StatusUnauthorized, StatusMisconfigured, "synthetic_api_key"},
+		{"403", http.StatusForbidden, StatusMisconfigured, "synthetic_api_key"},
+		{"429", http.StatusTooManyRequests, StatusOK, "rate limited"},
+		{"500", http.StatusInternalServerError, StatusUnreachable, "500"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotAuth string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				w.WriteHeader(tc.code)
+			}))
+			defer ts.Close()
+
+			status, detail := probeSynthetic(testCtx(t), ts.Client(), ts.URL, "syn-secret")
+			if status != tc.want {
+				t.Fatalf("status = %q (detail %q), want %q", status, detail, tc.want)
+			}
+			if gotAuth != "Bearer syn-secret" {
+				t.Errorf("Authorization header = %q, want Bearer syn-secret", gotAuth)
+			}
+			if tc.detail != "" && !strings.Contains(detail, tc.detail) {
+				t.Errorf("detail %q should contain %q", detail, tc.detail)
+			}
+			if strings.Contains(detail, "syn-secret") {
+				t.Errorf("detail leaked key: %q", detail)
+			}
+		})
+	}
+}
+
 // --- sourcegraph reachability ---
 
 func TestProbeReachable(t *testing.T) {
@@ -731,6 +787,9 @@ func TestBuildSpecsRequiredGating(t *testing.T) {
 	}
 	if s := findSpec(t, specs, "search", "parallel"); s.required {
 		t.Error("parallel not default must be informational")
+	}
+	if s := findSpec(t, specs, "search", "synthetic"); s.required {
+		t.Error("synthetic without a key and not default must be informational")
 	}
 	if s := findSpec(t, specs, "code", "grepapp"); !s.required {
 		t.Error("default code backend must be required")

--- a/doctor/probes.go
+++ b/doctor/probes.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -32,8 +33,9 @@ const (
 	keenableEndpoint = "https://api.keenable.ai"
 	tavilyEndpoint   = "https://api.tavily.com/search"
 	parallelEndpoint = "https://search.parallel.ai/mcp"
-	serpbaseEndpoint = "https://api.serpbase.dev/google/search"
-	githubAPIBase    = "https://api.github.com"
+	serpbaseEndpoint   = "https://api.serpbase.dev/google/search"
+	syntheticEndpoint  = "https://api.synthetic.new/v2/search"
+	githubAPIBase     = "https://api.github.com"
 	context7APIBase  = "https://context7.com"
 )
 
@@ -360,6 +362,40 @@ func probeSerpBase(ctx context.Context, client *http.Client, endpoint, apiKey st
 		return StatusOK, "reachable, key accepted (rate limited)"
 	case http.StatusPaymentRequired:
 		return StatusOK, "reachable, key accepted (search credits exhausted)"
+	default:
+		return StatusUnreachable, fmt.Sprintf("returned status %d", resp.StatusCode)
+	}
+}
+
+// probeSynthetic checks the Synthetic zero-data-retention web search API
+// with a minimal query. Synthetic uses a POST + Bearer auth shape.
+func probeSynthetic(ctx context.Context, client *http.Client, endpoint, apiKey string) (Status, string) {
+	key := strings.TrimSpace(apiKey)
+	if key == "" {
+		return StatusNoKey, "API key not set (get one at https://synthetic.new then: ketch config set synthetic_api_key <key>)"
+	}
+	body := []byte(`{"query":"ketch"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return StatusUnreachable, probeErrDetail(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return StatusUnreachable, probeErrDetail(err)
+	}
+	defer drain(resp)
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return StatusOK, ""
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return StatusMisconfigured, "API key rejected (ketch config set synthetic_api_key <key>)"
+	case http.StatusTooManyRequests:
+		return StatusOK, "reachable, key accepted (rate limited)"
 	default:
 		return StatusUnreachable, fmt.Sprintf("returned status %d", resp.StatusCode)
 	}

--- a/mcp/search.go
+++ b/mcp/search.go
@@ -14,7 +14,7 @@ import (
 // default backend/limit) stay operator-configured.
 type SearchInput struct {
 	Query      string   `json:"query" jsonschema:"the search query"`
-	Backend    string   `json:"backend,omitempty" jsonschema:"search backend: brave, ddg, searxng, exa, firecrawl, keenable, tavily, parallel, or serpbase (default: the configured backend)"`
+	Backend    string   `json:"backend,omitempty" jsonschema:"search backend: brave, ddg, searxng, exa, firecrawl, keenable, tavily, parallel, serpbase, or synthetic (default: the configured backend)"`
 	Multi      []string `json:"multi,omitempty" jsonschema:"federated search: backends to query and rank-fuse (reciprocal rank fusion), e.g. [\"brave\",\"ddg\"]; use [\"all\"] for every usable backend; mutually exclusive with backend and random; results gain a backends field showing which engines returned each"`
 	Random     []string `json:"random,omitempty" jsonschema:"random provider selection with sequential fallback on errors, e.g. [\"brave\",\"ddg\"]; use [\"all\"] for every usable backend; mutually exclusive with backend and multi"`
 	Limit      int      `json:"limit,omitempty" jsonschema:"max number of results (default: the configured limit)"`

--- a/search/config.go
+++ b/search/config.go
@@ -20,7 +20,7 @@ var ErrUnknownBackend = errors.New("unknown search backend")
 // single owner of the backend switch.
 func NewFromConfig(cfg *config.Config, backend, searxngURL string) (Searcher, error) {
 	switch backend {
-	case "brave", "exa", "firecrawl", "keenable", "tavily", "serpbase":
+	case "brave", "exa", "firecrawl", "keenable", "tavily", "serpbase", "synthetic":
 		return newCredentialAwareBackend(cfg, backend)
 	case "searxng":
 		if searxngURL == "" {
@@ -71,6 +71,12 @@ func newCredentialAwareBackend(cfg *config.Config, backend string) (Searcher, er
 			return nil, fmt.Errorf("serpbase: API key not set (get a free key at https://serpbase.dev then: ketch config set serpbase_api_key <key>)")
 		}
 		return newSerpBaseWithKeys(keys), nil
+	case "synthetic":
+		keys := cfg.SyntheticKeys()
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("synthetic: API key not set (get one at https://synthetic.new then: ketch config set synthetic_api_key <key>)")
+		}
+		return newSyntheticWithKeys(keys), nil
 	default:
 		return nil, fmt.Errorf("%w %q (available: %s)", ErrUnknownBackend, backend, strings.Join(config.AvailableBackends(), ", "))
 	}

--- a/search/synthetic.go
+++ b/search/synthetic.go
@@ -1,0 +1,143 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/1broseidon/ketch/httpx"
+)
+
+// syntheticEndpoint is the Synthetic zero-data-retention web search API.
+// Auth is Bearer-only in the Authorization header.
+const syntheticEndpoint = "https://api.synthetic.new/v2/search"
+
+// Synthetic searches the web via the Synthetic /v2/search API.
+type Synthetic struct {
+	keys   keyPool
+	client *http.Client
+}
+
+// NewSynthetic creates a new Synthetic search backend.
+func NewSynthetic(apiKey string) *Synthetic {
+	return newSyntheticWithKeys([]string{apiKey})
+}
+
+func newSyntheticWithKeys(keys []string) *Synthetic {
+	return &Synthetic{keys: newKeyPool(keys), client: httpx.Default()}
+}
+
+type syntheticRequest struct {
+	Query string `json:"query"`
+}
+
+type syntheticResponse struct {
+	Results []syntheticResult `json:"results"`
+}
+
+type syntheticResult struct {
+	URL       string `json:"url"`
+	Title     string `json:"title"`
+	Text      string `json:"text"`
+	Published string `json:"published"`
+}
+
+// Search queries Synthetic and returns up to limit results. The Synthetic
+// API returns its own extracted text per result; Description and Content are
+// both populated from it so callers reading either field get the full text.
+func (s *Synthetic) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	if limit <= 0 {
+		return []Result{}, nil
+	}
+
+	body, err := json.Marshal(syntheticRequest{Query: query})
+	if err != nil {
+		return nil, err
+	}
+
+	key := s.keys.pick()
+	resp, err := s.request(ctx, body, key)
+	if err != nil {
+		return nil, err
+	}
+	if syntheticRetryableStatus(resp.StatusCode) && s.keys.size() > 1 {
+		closeSearchResponse(resp)
+		key = s.keys.pickDifferent(key)
+		resp, err = s.request(ctx, body, key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, syntheticResponseError(resp, s.keys.keyLabel(key))
+	}
+
+	var sr syntheticResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return nil, fmt.Errorf("failed to decode synthetic response: %w", err)
+	}
+	return mapSyntheticResults(sr.Results, limit), nil
+}
+
+func mapSyntheticResults(raw []syntheticResult, limit int) []Result {
+	results := make([]Result, 0, limit)
+	for _, r := range raw {
+		if len(results) >= limit {
+			break
+		}
+		if r.URL == "" {
+			continue
+		}
+		results = append(results, Result{
+			Title:       r.Title,
+			URL:         r.URL,
+			Description: r.Text,
+			Content:     r.Text,
+		})
+	}
+	return results
+}
+
+func (s *Synthetic) request(ctx context.Context, body []byte, key string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, syntheticEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("synthetic request failed: %w", err)
+	}
+	return resp, nil
+}
+
+func syntheticRetryableStatus(status int) bool {
+	return status == http.StatusUnauthorized || status == http.StatusTooManyRequests
+}
+
+func syntheticResponseError(resp *http.Response, keyLabel string) error {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("synthetic: invalid API key (%s; set via: ketch config set synthetic_api_key <key>)", keyLabel)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("synthetic: rate limited (%s)", keyLabel)
+	default:
+		return syntheticStatusError(resp)
+	}
+}
+
+func syntheticStatusError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if detail := string(body); detail != "" {
+		return fmt.Errorf("synthetic returned status %d: %s", resp.StatusCode, detail)
+	}
+	return fmt.Errorf("synthetic returned status %d", resp.StatusCode)
+}


### PR DESCRIPTION
## What

Adds [Synthetic](https://synthetic.new) as a new search backend, backed by Synthetic's zero-data-retention web search API:

```
POST https://api.synthetic.new/v2/search
Authorization: Bearer $SYNTHETIC_API_KEY
{ "query": "..." }

→ { "results": [{ "url", "title", "text", "published" }] }
```

Synthetic is a private OpenAI-compatible LLM gateway that also exposes a dedicated `/v2/search` endpoint built for coding agents. It fit ketch's existing provider model cleanly, so this follows the same pattern as the other credential-aware backends (Brave/Tavily/SerpBase/etc.):

- **`search/synthetic.go`** — `Searcher` impl with key-pool rotation and retry on 401/429, mapping `text` into both `Description` and `Content` (like Tavily).
- **`config`** — `synthetic_api_key` (singular) + `synthetic_api_keys` (pool), env override `KETCH_SYNTHETIC_API_KEY`, `SyntheticKeys()` accessor, added to `AvailableBackends()`.
- **`search/config.go`** — factory case with a key-present precondition error (same shape as the other keyed backends).
- **`cmd/config.go`** — `config show` reports `synthetic_api_key_set` / `synthetic_api_keys_count`; `config set synthetic_api_key <key>` works; included in the redaction list.
- **`cmd/search.go`, `mcp/search.go`** — help text and MCP tool schema updated.
- **`doctor`** — `probeSynthetic` (POST + Bearer, mirrors `probeSerpBase`'s shape), a `buildSpecs` entry, and tests for no-key + status mapping.
- **Tests** — `config_test` `AvailableBackends` expectation, `cmd/search_test` `looksLikeBackendList` case, doctor probe + gating tests. All existing tests still pass.

## Setup

```sh
ketch config set synthetic_api_key <key>
ketch config set backend synthetic
ketch search "golang error handling"
```

Or via env:

```sh
KETCH_SYNTHETIC_API_KEY=<key> ketch search "golang error handling"
```

## Verification

Built and tested live against the Synthetic API — `ketch search`, `--json`, `--scrape`, and `ketch doctor` all green. `go test ./...` passes. Also packaged and tested in NixOS (`buildGoModule`).

## Notes

- The Synthetic API is marked "still under development" in their docs; the response shape (`results[].{url,title,text,published}`) is stable as of writing.
- Auth is Bearer-only in the `Authorization` header (never a query param), matching ketch's key-safety discipline.
- No new dependencies; uses the existing `httpx`, `keyPool`, and `closeSearchResponse` helpers.