### PR TITLE
ci: move workflows onto node24 action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -31,24 +31,24 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: site/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,19 +31,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.ref.outputs.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
 
       - run: go test ./...
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
Node 20 is deprecated on GitHub Actions runners, so every action still bundling the node20 runtime emits a deprecation warning. Each bump below targets a major whose `action.yml` declares `node24` (verified by reading `using:` at each tag):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-go` | v5 | v7 |
| `actions/setup-node` | v4 | v7 |
| `golangci/golangci-lint-action` | v8 | v9 |
| `goreleaser/goreleaser-action` | v6 | v7 |

`docs.yml` also moves the site build from `node-version: 20` to `24`. `peaceiris/actions-gh-pages@v4` needed no change — the floating `v4` tag already resolves to a node24 release.

## Breaking changes checked, none applicable

- **checkout v7** blocks fork-PR checkouts under `pull_request_target`/`workflow_run` — neither trigger is used.
- **setup-go v6** changed toolchain resolution — `go.mod` has no `toolchain` directive.
- **setup-node v5/v6** changed *automatic* caching — `docs.yml` configures `cache`/`cache-dependency-path` explicitly.
- **golangci-lint-action v9** still accepts `version: latest`, and `.golangci.yml` is already the required v2 schema.
- **goreleaser-action v7** is the node24/ESM bump; the v2 config default landed in v6.

## Verification

- All three workflow files parse as valid YAML.
- `npm run build` in `site/` succeeds on modern Node, so VitePress 1.6.4 is fine on 24.
- This PR's own CI run exercises the bumped `ci.yml`. `release.yml` only fires on a `v*` tag, so those bumps stay unexercised until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)