### PR TITLE
fix: Enable macOS runner and fix failing tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,13 @@ jobs:
           version: latest
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-26
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/1broseidon/ketch/config"
+	"github.com/1broseidon/ketch/internal/testutil"
 	"github.com/1broseidon/ketch/scrape"
 )
 
@@ -100,7 +101,7 @@ func TestRunConfigSetNeverEchoesSecrets(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.key, func(t *testing.T) {
-			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			testutil.SetIsolatedConfigHome(t)
 			output, err := captureStderr(t, func() error {
 				return runConfigSet(nil, []string{test.key, test.value})
 			})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/1broseidon/ketch/internal/testutil"
 )
 
 func TestParallelBackendIsAppendedWithoutChangingDefault(t *testing.T) {
@@ -50,7 +52,7 @@ func TestEffectiveKeysReturnCopies(t *testing.T) {
 }
 
 func TestSaveEnforcesPrivateMode(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.SetIsolatedConfigHome(t)
 	path, err := Path()
 	if err != nil {
 		t.Fatal(err)

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/1broseidon/ketch/internal/testutil"
 )
 
 // clearKetchEnv unsets every KETCH_* variable for the test so ambient
@@ -28,7 +30,7 @@ func TestEnvVarNaming(t *testing.T) {
 
 func TestLoadEnvOverlay(t *testing.T) {
 	clearKetchEnv(t)
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.SetIsolatedConfigHome(t)
 	t.Setenv("KETCH_BACKEND", "ddg")
 	t.Setenv("KETCH_LIMIT", "9")
 	t.Setenv("KETCH_CACHE_TTL", "30m")
@@ -94,7 +96,7 @@ func TestLoadEnvOverridesFile(t *testing.T) {
 
 func TestLoadInvalidEnvIsLoudButBestEffort(t *testing.T) {
 	clearKetchEnv(t)
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.SetIsolatedConfigHome(t)
 	t.Setenv("KETCH_LIMIT", "abc")
 	t.Setenv("KETCH_CACHE_TTL", "nope")
 	t.Setenv("KETCH_BACKEND", "ddg")
@@ -116,7 +118,7 @@ func TestLoadInvalidEnvIsLoudButBestEffort(t *testing.T) {
 
 func TestLoadEmptyEnvValueIsUnset(t *testing.T) {
 	clearKetchEnv(t)
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.SetIsolatedConfigHome(t)
 	t.Setenv("KETCH_LIMIT", "")
 
 	res, err := Load()

--- a/internal/testutil/config.go
+++ b/internal/testutil/config.go
@@ -1,0 +1,13 @@
+package testutil
+
+import "testing"
+
+// SetIsolatedConfigHome prevents tests from using the user's config directory.
+func SetIsolatedConfigHome(t testing.TB) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}

--- a/mcp/smoke_test.go
+++ b/mcp/smoke_test.go
@@ -7,8 +7,8 @@
 //
 //	go test -tags mcpsmoke ./mcp/... -run TestMCPServerSmoke -v
 //
-// The server subprocess runs with XDG_CACHE_HOME/XDG_CONFIG_HOME pointed at
-// a temp dir, so it sees default config (grepapp needs no key) and a fresh
+// The server subprocess runs with HOME/XDG_CACHE_HOME/XDG_CONFIG_HOME pointed
+// at a temp dir, so it sees default config (grepapp needs no key) and a fresh
 // page cache — which lets the scrape subtest prove shared-cache reuse.
 package mcp_test
 
@@ -41,6 +41,7 @@ func TestMCPServerSmoke(t *testing.T) {
 	isolated := t.TempDir()
 	serve := exec.Command(bin, "mcp", "serve")
 	serve.Env = append(os.Environ(),
+		"HOME="+isolated,
 		"XDG_CACHE_HOME="+isolated,
 		"XDG_CONFIG_HOME="+isolated,
 	)
@@ -152,7 +153,7 @@ func TestMCPServerSmoke(t *testing.T) {
 		}
 
 		// The server writes through its shared, server-lifetime cache handle;
-		// with XDG_CACHE_HOME isolated, this file exists only if that handle
+		// with HOME/XDG_CACHE_HOME isolated, this file exists only if that handle
 		// was actually opened and used.
 		cachePath := filepath.Join(isolated, "ketch", "cache.db")
 		info, err := os.Stat(cachePath)


### PR DESCRIPTION
A macOS build failure was reported while packaging Ketch in nixpkgs. The nixpkgs Hydra job history (https://hydra.nixos.org/job/nixpkgs/unstable/ketch.aarch64-darwin) shows that builds and tests ran successfully through version 0.10.0.

While investigating the failure, I noticed that the GitHub Actions test job only ran on Linux. This allowed a platform difference in Go’s config-directory discovery to go unnoticed: Linux respects XDG_CONFIG_HOME, while macOS derives the config directory from HOME.

This PR:

  - Adds macOS to the GitHub Actions test matrix alongside Linux.
  - Adds a shared SetIsolatedConfigHome test helper that sets HOME alongside XDG_CONFIG_HOME.
  - Uses the same isolation for the MCP smoke-test subprocess.

No application behavior or test functionality was changed. The existing tests now use platform-independent environment isolation and run on both Linux and macOS.

Happy to receive feedback.