### PR TITLE
fix(search): read Keenable result text from snippet, not description

### DIFF
--- a/search/keenable.go
+++ b/search/keenable.go
@@ -21,6 +21,11 @@ const keenableBaseURL = "https://api.keenable.ai"
 // by. Sent on every request so ketch usage is visible in adoption dashboards.
 const keenableTitle = "Ketch"
 
+// keenableSnippetMaxChars caps the text kept per result. Keenable returns the
+// whole page on every search result, an order of magnitude more than the other
+// backends here return.
+const keenableSnippetMaxChars = 500
+
 // Keenable searches via the Keenable web search API, a search index built for
 // AI agents. It is keyless by default (rate-limited); an optional API key lifts
 // the hourly cap and switches to the authenticated endpoint.
@@ -47,9 +52,26 @@ type keenableResponse struct {
 }
 
 type keenableResult struct {
-	Title       string `json:"title"`
-	URL         string `json:"url"`
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	// Snippet carries the page text. Description is the page's meta
+	// description and is empty for most pages, so it is only a fallback.
+	Snippet     string `json:"snippet"`
 	Description string `json:"description"`
+}
+
+// text returns the result's page text, collapsed to one line and capped at
+// keenableSnippetMaxChars.
+func (r keenableResult) text() string {
+	s := r.Snippet
+	if s == "" {
+		s = r.Description
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	if runes := []rune(s); len(runes) > keenableSnippetMaxChars {
+		s = string(runes[:keenableSnippetMaxChars])
+	}
+	return s
 }
 
 // Search queries Keenable and returns up to limit results.
@@ -101,7 +123,7 @@ func (k *Keenable) Search(ctx context.Context, query string, limit int) ([]Resul
 		results = append(results, Result{
 			Title:       r.Title,
 			URL:         r.URL,
-			Description: r.Description,
+			Description: r.text(),
 		})
 	}
 

--- a/search/search_feature_test.go
+++ b/search/search_feature_test.go
@@ -669,7 +669,7 @@ func TestFeatureKeenableSearchParses(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{
 			"results": [
-				{"title": "Go Docs", "url": "https://go.dev/doc/", "description": "Go documentation"},
+				{"title": "Go Docs", "url": "https://go.dev/doc/", "description": "", "snippet": "Go documentation"},
 				{"title": "Go Blog", "url": "https://go.dev/blog/", "description": "The Go Blog"}
 			]
 		}`)
@@ -692,6 +692,37 @@ func TestFeatureKeenableSearchParses(t *testing.T) {
 	}
 	if results[0].Description != "Go documentation" {
 		t.Errorf("description = %q, want %q", results[0].Description, "Go documentation")
+	}
+	// The second result carries only a meta description, which is the fallback.
+	if results[1].Description != "The Go Blog" {
+		t.Errorf("description = %q, want %q", results[1].Description, "The Go Blog")
+	}
+}
+
+func TestFeatureKeenableSnippetIsCollapsedAndCapped(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("word ", 400)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"results": [
+				{"title": "Wrapped", "url": "https://go.dev/a", "description": "", "snippet": "line one\n\nline two"},
+				{"title": "Long", "url": "https://go.dev/b", "description": "", "snippet": %q}
+			]
+		}`, long)
+	}))
+	defer server.Close()
+
+	k := &Keenable{client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := k.Search(context.Background(), "golang", 5)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if results[0].Description != "line one line two" {
+		t.Errorf("description = %q, want %q", results[0].Description, "line one line two")
+	}
+	if got := len([]rune(results[1].Description)); got != keenableSnippetMaxChars {
+		t.Errorf("description length = %d, want %d", got, keenableSnippetMaxChars)
 	}
 }
 


### PR DESCRIPTION
`keenableResult` has no `snippet` field, and that is where Keenable puts the page text. `description` is the page's meta description and is empty for most pages, so Keenable results print with nothing under the URL.

Decodes `snippet` now and falls back to `description`, collapsed to one line and capped at 500 chars because Keenable returns whole pages.
