### PR TITLE
fix(scrape): apply user_agent config to headless-browser fetches (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Headless-browser fetches now honor the operator-configured User-Agent (#45). The browser path wired the cookie jar through but never `user_agent`, so `--force-browser` always sent the headless browser's own UA — whose `HeadlessChrome` token is a hard 403 on some Akamai-fronted sites, exactly the pages the flag exists for. The configured UA (`user_agent` config, overridden by `--user-agent`) now launches the browser via Chrome's `--user-agent` switch, so it applies to every page, frame, and worker without changing the CLI surface. With nothing configured, the browser keeps its own UA — whether that default should stop advertising `HeadlessChrome` is tracked separately on the issue.
+
 ## [0.14.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Headless-browser fetches now honor the operator-configured User-Agent (#45). The browser path wired the cookie jar through but never `user_agent`, so `--force-browser` always sent the headless browser's own UA — whose `HeadlessChrome` token is a hard 403 on some Akamai-fronted sites, exactly the pages the flag exists for. The configured UA (`user_agent` config, overridden by `--user-agent`) now launches the browser via Chrome's `--user-agent` switch, so it applies to every page, frame, and worker without changing the CLI surface. With nothing configured, the browser keeps its own UA — whether that default should stop advertising `HeadlessChrome` is tracked separately on the issue.
+- Headless-browser fetches now honor configured `user_agent` and `--user-agent` values; when unset, Chromium's native User-Agent remains unchanged (#45).
 
 ## [0.14.0] - 2026-08-07
 

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -33,7 +33,7 @@ func init() {
 	crawlCmd.Flags().Bool("no-cache", false, "bypass the page cache")
 	crawlCmd.Flags().Bool("background", false, "run crawl in background, return immediately with crawl ID")
 	crawlCmd.Flags().String("cookie-file", "", "Netscape cookies.txt jar; matching cookies are sent with each fetch (overrides config cookie_file)")
-	crawlCmd.Flags().String("user-agent", "", "HTTP User-Agent override (overrides config user_agent; empty falls back to the built-in default)")
+	crawlCmd.Flags().String("user-agent", "", "User-Agent override (overrides config user_agent; applies to HTTP and browser fetches; empty falls back to the built-in default)")
 }
 
 func runCrawl(cmd *cobra.Command, args []string) error {

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -33,7 +33,7 @@ func init() {
 	crawlCmd.Flags().Bool("no-cache", false, "bypass the page cache")
 	crawlCmd.Flags().Bool("background", false, "run crawl in background, return immediately with crawl ID")
 	crawlCmd.Flags().String("cookie-file", "", "Netscape cookies.txt jar; matching cookies are sent with each fetch (overrides config cookie_file)")
-	crawlCmd.Flags().String("user-agent", "", "User-Agent override (overrides config user_agent; applies to HTTP and browser fetches; empty falls back to the built-in default)")
+	crawlCmd.Flags().String("user-agent", "", "User-Agent override (overrides config user_agent; applies to HTTP and browser fetches; empty restores each fetch path's default)")
 }
 
 func runCrawl(cmd *cobra.Command, args []string) error {

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -42,7 +42,7 @@ func init() {
 	scrapeCmd.Flags().Int("concurrency", 5, "max concurrent requests for multi-URL scraping")
 	scrapeCmd.Flags().Bool("force-browser", false, "always render via the configured browser, skipping JS-shell auto-detection")
 	scrapeCmd.Flags().String("cookie-file", "", "Netscape cookies.txt jar; matching cookies are sent with each fetch (overrides config cookie_file)")
-	scrapeCmd.Flags().String("user-agent", "", "User-Agent override (overrides config user_agent; applies to HTTP and browser fetches; empty falls back to the built-in default)")
+	scrapeCmd.Flags().String("user-agent", "", "User-Agent override (overrides config user_agent; applies to HTTP and browser fetches; empty restores each fetch path's default)")
 }
 
 func runScrape(cmd *cobra.Command, args []string) error {

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -42,7 +42,7 @@ func init() {
 	scrapeCmd.Flags().Int("concurrency", 5, "max concurrent requests for multi-URL scraping")
 	scrapeCmd.Flags().Bool("force-browser", false, "always render via the configured browser, skipping JS-shell auto-detection")
 	scrapeCmd.Flags().String("cookie-file", "", "Netscape cookies.txt jar; matching cookies are sent with each fetch (overrides config cookie_file)")
-	scrapeCmd.Flags().String("user-agent", "", "HTTP User-Agent override (overrides config user_agent; empty falls back to the built-in default)")
+	scrapeCmd.Flags().String("user-agent", "", "User-Agent override (overrides config user_agent; applies to HTTP and browser fetches; empty falls back to the built-in default)")
 }
 
 func runScrape(cmd *cobra.Command, args []string) error {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -45,7 +45,7 @@ func init() {
 		"random provider with fallback: comma-separated list, or bare/=all for every usable backend (use the = form, e.g. --random=brave,exa)")
 	searchCmd.Flags().Lookup("random").NoOptDefVal = "all"
 	searchCmd.Flags().String("cookie-file", "", "Netscape cookies.txt jar for --scrape fetches; matching cookies are sent with each fetch (overrides config cookie_file)")
-	searchCmd.Flags().String("user-agent", "", "HTTP User-Agent override for --scrape fetches (overrides config user_agent; empty falls back to the built-in default)")
+	searchCmd.Flags().String("user-agent", "", "User-Agent override for --scrape fetches (overrides config user_agent; applies to HTTP and browser fetches; empty falls back to the built-in default)")
 }
 
 func runSearch(cmd *cobra.Command, args []string) error {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -45,7 +45,7 @@ func init() {
 		"random provider with fallback: comma-separated list, or bare/=all for every usable backend (use the = form, e.g. --random=brave,exa)")
 	searchCmd.Flags().Lookup("random").NoOptDefVal = "all"
 	searchCmd.Flags().String("cookie-file", "", "Netscape cookies.txt jar for --scrape fetches; matching cookies are sent with each fetch (overrides config cookie_file)")
-	searchCmd.Flags().String("user-agent", "", "User-Agent override for --scrape fetches (overrides config user_agent; applies to HTTP and browser fetches; empty falls back to the built-in default)")
+	searchCmd.Flags().String("user-agent", "", "User-Agent override for --scrape fetches (overrides config user_agent; applies to HTTP and browser fetches; empty restores each fetch path's default)")
 }
 
 func runSearch(cmd *cobra.Command, args []string) error {

--- a/scrape/browser.go
+++ b/scrape/browser.go
@@ -22,18 +22,37 @@ type rodConn struct {
 	jar      *cookies.Jar
 }
 
+// ConnOption customizes a browser connection before the browser launches.
+type ConnOption func(*launcher.Launcher)
+
+// WithUserAgent launches the browser with the given User-Agent (Chrome's
+// --user-agent switch), in effect for every page, frame, and worker the
+// connection serves. An empty value is a no-op: the browser keeps its own
+// User-Agent, which under headless mode advertises the HeadlessChrome token.
+func WithUserAgent(ua string) ConnOption {
+	return func(l *launcher.Launcher) {
+		if ua != "" {
+			l.Set("user-agent", ua)
+		}
+	}
+}
+
 // NewBrowserConn launches a headless browser without cookie injection. This
 // legacy signature is preserved for external package callers.
 func NewBrowserConn(binPath string) (BrowserConn, error) {
 	return NewBrowserConnWithCookies(binPath, nil)
 }
 
-// NewBrowserConnWithCookies launches a headless browser and injects cookies
-// from jar (which may be nil) before each navigation.
-func NewBrowserConnWithCookies(binPath string, jar *cookies.Jar) (BrowserConn, error) {
+// NewBrowserConnWithCookies launches a headless browser, injects cookies from
+// jar (which may be nil) before each navigation, and applies opts to the
+// launcher before launch.
+func NewBrowserConnWithCookies(binPath string, jar *cookies.Jar, opts ...ConnOption) (BrowserConn, error) {
 	// Scrub KETCH_* secret vars (API keys, tokens) from the browser's
 	// environment — the child process has no use for ketch credentials.
 	l := launcher.New().Bin(binPath).Headless(true).Env(config.ScrubbedEnviron()...)
+	for _, opt := range opts {
+		opt(l)
+	}
 	u, err := l.Launch()
 	if err != nil {
 		return nil, fmt.Errorf("launch browser: %w", err)

--- a/scrape/browser.go
+++ b/scrape/browser.go
@@ -40,13 +40,21 @@ func WithUserAgent(ua string) ConnOption {
 // NewBrowserConn launches a headless browser without cookie injection. This
 // legacy signature is preserved for external package callers.
 func NewBrowserConn(binPath string) (BrowserConn, error) {
-	return NewBrowserConnWithCookies(binPath, nil)
+	return NewBrowserConnOptions(binPath, nil)
 }
 
-// NewBrowserConnWithCookies launches a headless browser, injects cookies from
-// jar (which may be nil) before each navigation, and applies opts to the
-// launcher before launch.
-func NewBrowserConnWithCookies(binPath string, jar *cookies.Jar, opts ...ConnOption) (BrowserConn, error) {
+// NewBrowserConnWithCookies launches a headless browser and injects cookies
+// from jar (which may be nil) before each navigation. The signature is kept
+// exact (not variadic) so existing assignments to the function type keep
+// compiling; use NewBrowserConnOptions for launch-time customization.
+func NewBrowserConnWithCookies(binPath string, jar *cookies.Jar) (BrowserConn, error) {
+	return NewBrowserConnOptions(binPath, jar)
+}
+
+// NewBrowserConnOptions launches a headless browser, injects cookies from jar
+// (which may be nil) before each navigation, and applies opts to the launcher
+// before launch.
+func NewBrowserConnOptions(binPath string, jar *cookies.Jar, opts ...ConnOption) (BrowserConn, error) {
 	// Scrub KETCH_* secret vars (API keys, tokens) from the browser's
 	// environment — the child process has no use for ketch credentials.
 	l := launcher.New().Bin(binPath).Headless(true).Env(config.ScrubbedEnviron()...)

--- a/scrape/browser_test.go
+++ b/scrape/browser_test.go
@@ -1,0 +1,73 @@
+package scrape
+
+import (
+	"testing"
+
+	"github.com/1broseidon/ketch/config"
+	"github.com/go-rod/rod/lib/launcher"
+)
+
+// browserConnOptions must pass the operator's UA to the browser only when one
+// was explicitly configured — the unconfigured case must stay a no-op so the
+// browser keeps its own User-Agent.
+func TestBrowserConnOptionsFollowConfig(t *testing.T) {
+	s := New()
+	if opts := s.browserConnOptions(); len(opts) != 0 {
+		t.Errorf("unconfigured scraper: browserConnOptions() = %d options, want none", len(opts))
+	}
+
+	s.userAgent = "custom/1.2"
+	s.userAgentConfigured = true
+	opts := s.browserConnOptions()
+	if len(opts) != 1 {
+		t.Fatalf("configured scraper: browserConnOptions() = %d options, want 1", len(opts))
+	}
+	if opts[0] == nil {
+		t.Fatal("configured scraper: browserConnOptions()[0] = nil, want WithUserAgent")
+	}
+}
+
+func TestNewFromConfigUserAgentFlowsToBrowser(t *testing.T) {
+	s, err := NewFromConfig(&config.Config{UserAgent: "custom/1.2"})
+	if err != nil {
+		t.Fatalf("NewFromConfig with user_agent: %v", err)
+	}
+	if !s.userAgentConfigured {
+		t.Error("explicit user_agent: userAgentConfigured = false, want true")
+	}
+	if s.userAgent != "custom/1.2" {
+		t.Errorf("explicit user_agent: userAgent = %q, want %q", s.userAgent, "custom/1.2")
+	}
+	if opts := s.browserConnOptions(); len(opts) != 1 {
+		t.Errorf("explicit user_agent: browserConnOptions() = %d options, want 1", len(opts))
+	}
+
+	s2, err := NewFromConfig(&config.Config{})
+	if err != nil {
+		t.Fatalf("NewFromConfig without user_agent: %v", err)
+	}
+	if s2.userAgentConfigured {
+		t.Error("no user_agent: userAgentConfigured = true, want false")
+	}
+	if s2.userAgent != DefaultUserAgent() {
+		t.Errorf("no user_agent: userAgent = %q, want default %q", s2.userAgent, DefaultUserAgent())
+	}
+	if opts := s2.browserConnOptions(); len(opts) != 0 {
+		t.Errorf("no user_agent: browserConnOptions() = %d options, want none", len(opts))
+	}
+}
+
+// WithUserAgent must be a no-op for an empty UA so the default launch never
+// carries a --user-agent switch.
+func TestWithUserAgentEmptyIsNoOp(t *testing.T) {
+	l := launcher.New()
+	WithUserAgent("")(l)
+	if l.Has("user-agent") {
+		t.Error("WithUserAgent(\"\"): launcher got a user-agent flag, want none")
+	}
+
+	WithUserAgent("custom/1.2")(l)
+	if got := l.Get("user-agent"); got != "custom/1.2" {
+		t.Errorf("WithUserAgent(\"custom/1.2\"): launcher user-agent = %q, want %q", got, "custom/1.2")
+	}
+}

--- a/scrape/browser_test.go
+++ b/scrape/browser_test.go
@@ -4,12 +4,18 @@ import (
 	"testing"
 
 	"github.com/1broseidon/ketch/config"
+	"github.com/1broseidon/ketch/cookies"
 	"github.com/go-rod/rod/lib/launcher"
 )
 
+// Source compatibility: NewBrowserConnWithCookies's signature was deliberately
+// kept exact (not variadic) so external assignments to the function type keep
+// compiling.
+var _ func(string, *cookies.Jar) (BrowserConn, error) = NewBrowserConnWithCookies
+
 // browserConnOptions must pass the operator's UA to the browser only when one
-// was explicitly configured — the unconfigured case must stay a no-op so the
-// browser keeps its own User-Agent.
+// was explicitly configured — both the presence and the value must survive the
+// option boundary onto a real launcher.
 func TestBrowserConnOptionsFollowConfig(t *testing.T) {
 	s := New()
 	if opts := s.browserConnOptions(); len(opts) != 0 {
@@ -22,8 +28,10 @@ func TestBrowserConnOptionsFollowConfig(t *testing.T) {
 	if len(opts) != 1 {
 		t.Fatalf("configured scraper: browserConnOptions() = %d options, want 1", len(opts))
 	}
-	if opts[0] == nil {
-		t.Fatal("configured scraper: browserConnOptions()[0] = nil, want WithUserAgent")
+	l := launcher.New()
+	opts[0](l)
+	if got := l.Get("user-agent"); got != "custom/1.2" {
+		t.Errorf("configured scraper: option set user-agent = %q, want %q", got, "custom/1.2")
 	}
 }
 

--- a/scrape/pipeline.go
+++ b/scrape/pipeline.go
@@ -61,6 +61,7 @@ func NewFromConfig(cfg *config.Config) (*Scraper, error) {
 		return nil, fmt.Errorf("invalid user_agent: %w", err)
 	}
 	scraper.userAgent = ua
+	scraper.userAgentConfigured = strings.TrimSpace(cfg.UserAgent) != ""
 	if cfg.CookieFile != "" {
 		jar, err := cookies.Load(cfg.CookieFile)
 		if err != nil {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -87,6 +87,11 @@ type Scraper struct {
 	rewriter     *urlrewrite.Rewriter
 	jar          *cookies.Jar
 	userAgent    string
+	// userAgentConfigured records that the operator explicitly set user_agent
+	// (config, env, or flag) instead of riding the built-in default. Only an
+	// explicitly configured UA reaches the headless browser; when unset, the
+	// browser keeps its own User-Agent.
+	userAgentConfigured bool
 }
 
 // NewWithRewriter creates a Scraper with an optional browser binary and
@@ -171,7 +176,7 @@ func (s *Scraper) getBrowser() BrowserConn {
 		s.browserBin = ""
 		return nil
 	}
-	conn, err := NewBrowserConnWithCookies(bin, s.jar)
+	conn, err := NewBrowserConnWithCookies(bin, s.jar, s.browserConnOptions()...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warn: browser init failed: %v\n", err)
 		s.browserBin = ""
@@ -179,6 +184,17 @@ func (s *Scraper) getBrowser() BrowserConn {
 	}
 	s.browser = conn
 	return s.browser
+}
+
+// browserConnOptions returns the launch-time options for the headless browser.
+// The operator's user_agent (config, env, or --user-agent flag) applies to the
+// browser path exactly like the HTTP path; when nothing is configured, no UA
+// option is passed and the launch keeps the browser's own User-Agent.
+func (s *Scraper) browserConnOptions() []ConnOption {
+	if !s.userAgentConfigured {
+		return nil
+	}
+	return []ConnOption{WithUserAgent(s.userAgent)}
 }
 
 // Scrape fetches a URL and returns extracted markdown content along with the

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -176,7 +176,7 @@ func (s *Scraper) getBrowser() BrowserConn {
 		s.browserBin = ""
 		return nil
 	}
-	conn, err := NewBrowserConnWithCookies(bin, s.jar, s.browserConnOptions()...)
+	conn, err := NewBrowserConnOptions(bin, s.jar, s.browserConnOptions()...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warn: browser init failed: %v\n", err)
 		s.browserBin = ""


### PR DESCRIPTION
## What

The browser path (Rod) wired the cookie jar through but never the configured User-Agent, so `--force-browser` always sent the headless browser's own UA — which under headless mode contains the `HeadlessChrome` token, a bot signal that some Akamai-fronted sites answer with a hard 403. That made the flag unusable on exactly the pages it exists for.

`user_agent` (config, env, or `--user-agent` flag) now launches the browser with Chrome's `--user-agent` switch: one launch-time call, in effect for every page, frame, and worker the connection serves. With nothing configured, the browser keeps its own UA — that default decision is tracked separately on the issue.

## Changes

- `scrape/browser.go`: new `NewBrowserConnOptions(bin, jar, opts ...ConnOption)` carries the options; `NewBrowserConnWithCookies` keeps its exact non-variadic signature (assignments to the function type keep compiling) and delegates to it; new `WithUserAgent` sets the launch switch (empty = no-op).
- `scrape/scrape.go`: `Scraper` records whether the operator explicitly configured a UA (`userAgentConfigured`); `getBrowser` forwards it via `browserConnOptions`.
- `scrape/pipeline.go`: `NewFromConfig` sets the flag when `cfg.UserAgent` is non-empty.
- Flags: `--user-agent` help now says it applies to HTTP *and* browser fetches.
- Tests: `browserConnOptions` wiring (`NewFromConfig` with/without `user_agent`), `WithUserAgent` empty no-op + switch value.

## Why launch switch, not page-level override

Chrome's `--user-agent` applies process-wide and costs nothing per fetch; a page-level CDP `SetUserAgentOverride` would need to be re-applied for every new tab (`Fetch` creates one per call) and would not cover workers. The launch switch is also consistent with how cookies are already handled — a browser-session property, not per-page state.

## Verification

Reproduced the issue against `browserleaks.com/ip` on a real Chrome:

| case | UA seen by the site |
|---|---|
| `user_agent` set (config) | configured Firefox UA ✔ (previously `HeadlessChrome/151`) |
| `--user-agent` flag | flag value ✔ |
| nothing configured | `HeadlessChrome/152.0.0.0` (unchanged — deliberate) |

`gofmt`, `go vet`, `golangci-lint run`, `go test ./...` all pass.

Addresses the explicitly-configured half of #45. Whether the *default* browser UA should stop advertising `HeadlessChrome` remains open on that issue for a separate decision.

