### PR TITLE
scrape: stop advertising HeadlessChrome by default in browser fetches (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Headless-browser fetches now honor configured `user_agent` and `--user-agent` values; when unset, Chromium's native User-Agent remains unchanged (#45).
+- Headless-browser fetches no longer advertise `HeadlessChrome` by default (#45). With no `user_agent` configured, ketch reads the installed browser's own User-Agent after launch and, when it carries the `HeadlessChrome/` product token, relaunches once with that same string minus the `Headless` prefix. Version, platform, and `sec-ch-ua` client hints stay truthful — the browser presents as itself in normal mode, which is what lets `--force-browser` get past Akamai-style filters that hard-403 the headless token. A configured `user_agent` / `--user-agent` still wins unchanged.
 
 ## [0.14.0] - 2026-08-07
 

--- a/scrape/browser.go
+++ b/scrape/browser.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/1broseidon/ketch/config"
@@ -28,13 +29,33 @@ type ConnOption func(*launcher.Launcher)
 // WithUserAgent launches the browser with the given User-Agent (Chrome's
 // --user-agent switch), in effect for every page, frame, and worker the
 // connection serves. An empty value is a no-op: the browser keeps its own
-// User-Agent, which under headless mode advertises the HeadlessChrome token.
+// User-Agent with only the Headless token removed (see stripHeadlessUA).
 func WithUserAgent(ua string) ConnOption {
 	return func(l *launcher.Launcher) {
 		if ua != "" {
 			l.Set("user-agent", ua)
 		}
 	}
+}
+
+// headlessToken is the product-name prefix headless Chromium advertises in
+// its User-Agent (e.g. "HeadlessChrome/151.0.0.0"). It is a strong bot
+// signal: Akamai and similar filters answer a hard 403 to it, which made
+// --force-browser unusable on exactly the sites it exists for (#45).
+const headlessToken = "HeadlessChrome/"
+
+// stripHeadlessUA returns the browser's User-Agent as it would read in normal
+// (non-headless) mode: the "Headless" prefix on the Chrome product token is
+// removed and nothing else changes. Version, platform, and the sec-ch-ua
+// client hints all stay truthful — the browser presents as itself, not as
+// some other browser. The second return reports whether anything changed, so
+// a UA without the token (a non-Chromium build, or one already overridden)
+// is left alone.
+func stripHeadlessUA(ua string) (string, bool) {
+	if !strings.Contains(ua, headlessToken) {
+		return ua, false
+	}
+	return strings.Replace(ua, headlessToken, "Chrome/", 1), true
 }
 
 // NewBrowserConn launches a headless browser without cookie injection. This
@@ -54,7 +75,42 @@ func NewBrowserConnWithCookies(binPath string, jar *cookies.Jar) (BrowserConn, e
 // NewBrowserConnOptions launches a headless browser, injects cookies from jar
 // (which may be nil) before each navigation, and applies opts to the launcher
 // before launch.
+//
+// When no option sets a User-Agent, the browser's own UA is read after launch
+// and, if it carries the HeadlessChrome token, the browser is relaunched once
+// with that same UA minus the Headless prefix (stripHeadlessUA). Doing this
+// through the launch switch rather than a per-page CDP override keeps the
+// coverage identical to a configured user_agent: every page, frame, and
+// worker. The extra launch costs a fraction of a second once per process.
 func NewBrowserConnOptions(binPath string, jar *cookies.Jar, opts ...ConnOption) (BrowserConn, error) {
+	l, b, err := launchBrowser(binPath, opts)
+	if err != nil {
+		return nil, err
+	}
+	if l.Has("user-agent") {
+		return &rodConn{browser: b, launcher: l, jar: jar}, nil
+	}
+
+	ua, err := browserUserAgent(b)
+	if err != nil {
+		closeBrowser(b, l)
+		return nil, err
+	}
+	stripped, changed := stripHeadlessUA(ua)
+	if !changed {
+		return &rodConn{browser: b, launcher: l, jar: jar}, nil
+	}
+	closeBrowser(b, l)
+	l, b, err = launchBrowser(binPath, append(opts, WithUserAgent(stripped)))
+	if err != nil {
+		return nil, err
+	}
+	return &rodConn{browser: b, launcher: l, jar: jar}, nil
+}
+
+// launchBrowser starts a headless browser with opts applied and connects to
+// it, returning the launcher and connected browser.
+func launchBrowser(binPath string, opts []ConnOption) (*launcher.Launcher, *rod.Browser, error) {
 	// Scrub KETCH_* secret vars (API keys, tokens) from the browser's
 	// environment — the child process has no use for ketch credentials.
 	l := launcher.New().Bin(binPath).Headless(true).Env(config.ScrubbedEnviron()...)
@@ -63,7 +119,7 @@ func NewBrowserConnOptions(binPath string, jar *cookies.Jar, opts ...ConnOption)
 	}
 	u, err := l.Launch()
 	if err != nil {
-		return nil, fmt.Errorf("launch browser: %w", err)
+		return nil, nil, fmt.Errorf("launch browser: %w", err)
 	}
 	// Rod emulates devices.LaptopWithMDPIScreen by default, which overrides the
 	// user agent with a hardcoded macOS Chrome 114 string. That advertises a
@@ -73,9 +129,23 @@ func NewBrowserConnOptions(binPath string, jar *cookies.Jar, opts ...ConnOption)
 	b := rod.New().ControlURL(u).DefaultDevice(devices.Clear)
 	if err := b.Connect(); err != nil {
 		l.Kill()
-		return nil, fmt.Errorf("connect browser: %w", err)
+		return nil, nil, fmt.Errorf("connect browser: %w", err)
 	}
-	return &rodConn{browser: b, launcher: l, jar: jar}, nil
+	return l, b, nil
+}
+
+// browserUserAgent asks the running browser for the User-Agent it will send.
+func browserUserAgent(b *rod.Browser) (string, error) {
+	v, err := b.Version()
+	if err != nil {
+		return "", fmt.Errorf("browser version: %w", err)
+	}
+	return v.UserAgent, nil
+}
+
+func closeBrowser(b *rod.Browser, l *launcher.Launcher) {
+	_ = b.Close()
+	l.Kill()
 }
 
 // Fetch navigates to a URL in a new tab and returns the rendered HTML.

--- a/scrape/browser_test.go
+++ b/scrape/browser_test.go
@@ -79,3 +79,75 @@ func TestWithUserAgentEmptyIsNoOp(t *testing.T) {
 		t.Errorf("WithUserAgent(\"custom/1.2\"): launcher user-agent = %q, want %q", got, "custom/1.2")
 	}
 }
+
+// stripHeadlessUA must turn the headless product token into the normal-mode
+// one and leave everything else — version, platform, engine tokens — intact,
+// and must report no change for UAs that never carried the token.
+func TestStripHeadlessUA(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		changed bool
+	}{
+		{
+			name:    "linux headless chromium",
+			in:      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/151.0.0.0 Safari/537.36",
+			want:    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+			changed: true,
+		},
+		{
+			name:    "macos headless chrome",
+			in:      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/140.0.0.0 Safari/537.36",
+			want:    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+			changed: true,
+		},
+		{
+			name:    "already normal mode",
+			in:      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+			want:    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+			changed: false,
+		},
+		{
+			name:    "non-chromium",
+			in:      "Mozilla/5.0 (X11; Linux x86_64; rv:153.0) Gecko/20100101 Firefox/153.0",
+			want:    "Mozilla/5.0 (X11; Linux x86_64; rv:153.0) Gecko/20100101 Firefox/153.0",
+			changed: false,
+		},
+		{
+			name:    "empty",
+			in:      "",
+			want:    "",
+			changed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := stripHeadlessUA(tt.in)
+			if got != tt.want {
+				t.Errorf("stripHeadlessUA(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if changed != tt.changed {
+				t.Errorf("stripHeadlessUA(%q) changed = %v, want %v", tt.in, changed, tt.changed)
+			}
+		})
+	}
+}
+
+// A configured UA must win over the headless strip: NewBrowserConnOptions
+// decides by whether the launcher already carries a user-agent switch, so the
+// option must register one the launcher can see.
+func TestWithUserAgentMarksLauncher(t *testing.T) {
+	l := launcher.New()
+	if l.Has("user-agent") {
+		t.Fatal("fresh launcher already has user-agent")
+	}
+	WithUserAgent("")(l)
+	if l.Has("user-agent") {
+		t.Error("WithUserAgent(\"\") must not set user-agent")
+	}
+	WithUserAgent("custom/1.2")(l)
+	if !l.Has("user-agent") {
+		t.Error("WithUserAgent(\"custom/1.2\") did not set user-agent")
+	}
+}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -90,7 +90,8 @@ type Scraper struct {
 	// userAgentConfigured records that the operator explicitly set user_agent
 	// (config, env, or flag) instead of riding the built-in default. Only an
 	// explicitly configured UA reaches the headless browser; when unset, the
-	// browser keeps its own User-Agent.
+	// browser keeps its own User-Agent minus the HeadlessChrome token (see
+	// NewBrowserConnOptions).
 	userAgentConfigured bool
 }
 
@@ -189,7 +190,8 @@ func (s *Scraper) getBrowser() BrowserConn {
 // browserConnOptions returns the launch-time options for the headless browser.
 // The operator's user_agent (config, env, or --user-agent flag) applies to the
 // browser path exactly like the HTTP path; when nothing is configured, no UA
-// option is passed and the launch keeps the browser's own User-Agent.
+// option is passed and the launch keeps the browser's own User-Agent with the
+// HeadlessChrome token stripped.
 func (s *Scraper) browserConnOptions() []ConnOption {
 	if !s.userAgentConfigured {
 		return nil


### PR DESCRIPTION
Closes #45 — implements option 3 from the issue thread.

## What changed

With no `user_agent` configured, `NewBrowserConnOptions` now reads the installed browser's own User-Agent after launch (`Browser.Version()`). If it carries the `HeadlessChrome/` product token, the browser is relaunched once with that same string minus the `Headless` prefix. Version, platform, and `sec-ch-ua` client hints stay truthful — the browser presents as itself in normal mode, which is what lets `--force-browser` get past Akamai-style filters that hard-403 the headless token.

- Uses the `--user-agent` launch switch rather than a per-page CDP override, so coverage is identical to a configured `user_agent`: every page, frame, and worker.
- A configured `user_agent` / `--user-agent` still wins unchanged; the decision is made by whether the launcher already carries a `user-agent` switch, so no new plumbing through `Scraper`.
- Non-Chromium builds or UAs without the token are left alone (no relaunch).
- The extra launch costs a fraction of a second once per process, only when the token is present.

## Verification

- `stripHeadlessUA` unit tests (Linux/macOS headless, already-normal, Firefox, empty) plus a test that `WithUserAgent` registers the switch the strip logic keys off.
- Live check against a local UA-echo server with Chromium 141: default now sends `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36`; `--user-agent custom/9.9` sends `custom/9.9`.
- `gofmt`, `go vet`, `golangci-lint` (0 issues), `go test ./...` all clean.

CHANGELOG updated under Unreleased / Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkgAwsDs8rtbqr6nrYRqoU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkgAwsDs8rtbqr6nrYRqoU)_