### PR TITLE
feat(search): make hosted Firecrawl keyless by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ ketch search "query"                        # search, return results
 ketch search "query" --scrape               # search + fetch full content
 ketch search "query" -b searxng             # use SearXNG backend
 ketch search "query" -b exa                 # use Exa hosted MCP backend
-ketch search "query" -b firecrawl           # use Firecrawl v2 search API
+ketch search "query" -b firecrawl           # use Firecrawl v2 search API (keyless by default)
 ketch search "query" -b keenable            # use Keenable backend (keyless by default)
 ketch search "query" -b tavily              # use Tavily search API (keyed; basic depth)
 ketch search "query" -b parallel            # use Parallel Search MCP (keyless)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Hosted Firecrawl search is keyless by default. `ketch search -b firecrawl` no longer requires `firecrawl_api_key`; the same `POST /v2/search` call omits `Authorization` when no key is set, and `--multi=all` / `--random=all` include Firecrawl on a zero-config install. An optional key still lifts rate limits and credits, and still rotates on `401`/`429`/`402`. Self-hosted `firecrawl_url` is unchanged. `ketch doctor` probes the hosted endpoint instead of reporting `no_key`; the probe sends `integration: "_ketch"` like search, and a keyless hosted `403` is reported as reachable (same class as `429`) instead of `misconfigured`.
+
 ## [0.16.1] - 2026-09-07
 
 Version 0.16.0 was published on 2026-09-07 and withdrawn the same day; its Read the Docs backend and Context7 candidate resolution were not ready. The Go module proxy retains it, so this release carries a `retract v0.16.0` directive. 0.16.1 is 0.15.0 plus the fixes below and contains none of the 0.16.0 additions.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Every command supports `-h/--help` for its full flag list; `--json` is the only 
 
 | Surface | Default | Also available | Setup |
 |---|---|---|---|
-| `search` | `brave` | `ddg`, `searxng`, `exa`, `firecrawl`, `keenable`, `tavily`, `parallel`, `serpbase`, `degoog` | Brave, Firecrawl, Tavily, and SerpBase need a free key (`ketch config set brave_api_key <key>` / `firecrawl_api_key` / `tavily_api_key` / `serpbase_api_key`); `ddg`, `searxng`, `exa`, `keenable`, and `parallel` work with zero config; `degoog` needs a self-hosted instance (`ketch config set degoog_url <url>`) |
+| `search` | `brave` | `ddg`, `searxng`, `exa`, `firecrawl`, `keenable`, `tavily`, `parallel`, `serpbase`, `degoog` | Brave, Tavily, and SerpBase need a free key (`ketch config set brave_api_key <key>` / `tavily_api_key` / `serpbase_api_key`); `ddg`, `searxng`, `exa`, `firecrawl`, `keenable`, and `parallel` work with zero config (`firecrawl_api_key` is optional and lifts Firecrawl's hosted cap); `degoog` needs a self-hosted instance (`ketch config set degoog_url <url>`) |
 | `code` | `grepapp` | `sourcegraph`, `github` | Grep and Sourcegraph need nothing; GitHub uses `gh auth login`, `$GITHUB_TOKEN`, or `ketch config set github_token <tok>` |
 | `docs` | `context7` | `local` (planned, not yet implemented) | Free key: `ketch config set context7_api_key <key>` |
 

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -59,7 +59,7 @@ func TestRunMultiSearchFlagValidation(t *testing.T) {
 		{"multi and backend conflict", "brave", true, ExitValidation, "mutually exclusive"},
 		{"all combined with a name", "all,brave", false, ExitValidation, `"all" cannot be combined`},
 		{"unknown backend", "bogus", false, ExitValidation, "unknown search backend"},
-		{"named but unconfigured", "firecrawl", false, ExitPrecondition, "firecrawl"},
+		{"named but unconfigured", "tavily", false, ExitPrecondition, "tavily"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestRunRandomSearchBackendValidation(t *testing.T) {
 		wantSubstr string
 	}{
 		{name: "unknown backend", random: "bogus", wantCode: ExitValidation, wantSubstr: "unknown search backend"},
-		{name: "named but unconfigured", random: "firecrawl", wantCode: ExitPrecondition, wantSubstr: "firecrawl"},
+		{name: "named but unconfigured", random: "tavily", wantCode: ExitPrecondition, wantSubstr: "tavily"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -142,28 +142,33 @@ func TestProbeFirecrawlNoKey(t *testing.T) {
 
 func TestProbeFirecrawlHostedStatuses(t *testing.T) {
 	cases := []struct {
-		name string
-		key  string
-		code int
-		want Status
+		name       string
+		key        string
+		code       int
+		want       Status
+		wantDetail string // substring; empty skips the detail check
 	}{
-		{"keyless ok", "", http.StatusOK, StatusOK},
-		{"keyless rate limited", "", http.StatusTooManyRequests, StatusOK},
-		{"keyless credits", "", http.StatusPaymentRequired, StatusMisconfigured},
-		{"keyless unauthorized", "", http.StatusUnauthorized, StatusMisconfigured},
-		{"keyless forbidden", "", http.StatusForbidden, StatusOK},
-		{"keyed rate limited", "k", http.StatusTooManyRequests, StatusOK},
-		{"keyed rejected", "k", http.StatusUnauthorized, StatusMisconfigured},
-		{"keyed forbidden", "k", http.StatusForbidden, StatusMisconfigured},
+		{"keyless ok", "", http.StatusOK, StatusOK, ""},
+		{"keyless rate limited", "", http.StatusTooManyRequests, StatusOK, "rate limited"},
+		{"keyless credits", "", http.StatusPaymentRequired, StatusMisconfigured, "credits exhausted"},
+		{"keyless unauthorized", "", http.StatusUnauthorized, StatusMisconfigured, "request rejected"},
+		{"keyless forbidden", "", http.StatusForbidden, StatusOK, "keyless blocked"},
+		{"keyed rate limited", "k", http.StatusTooManyRequests, StatusOK, "key accepted"},
+		{"keyed rejected", "k", http.StatusUnauthorized, StatusMisconfigured, "API key rejected"},
+		{"keyed forbidden", "k", http.StatusForbidden, StatusMisconfigured, "API key rejected"},
+		{"keyed credits", "k", http.StatusPaymentRequired, StatusMisconfigured, "credits exhausted"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := &http.Client{Transport: probeRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 				return &http.Response{StatusCode: tc.code, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{}`))}, nil
 			})}
-			status, _ := probeFirecrawl(testCtx(t), client, config.FirecrawlSearchURL(config.DefaultFirecrawlURL), tc.key)
+			status, detail := probeFirecrawl(testCtx(t), client, config.FirecrawlSearchURL(config.DefaultFirecrawlURL), tc.key)
 			if status != tc.want {
-				t.Fatalf("status = %q, want %q", status, tc.want)
+				t.Fatalf("status = %q (detail %q), want %q", status, detail, tc.want)
+			}
+			if tc.wantDetail != "" && !strings.Contains(detail, tc.wantDetail) {
+				t.Errorf("detail = %q, want substring %q", detail, tc.wantDetail)
 			}
 		})
 	}

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -113,18 +113,59 @@ func TestProbeBraveNoKey(t *testing.T) {
 }
 
 func TestProbeFirecrawlNoKey(t *testing.T) {
-	// Must classify without any network call: the handler fails the test.
-	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-		t.Error("no-key probe must not hit the network")
-	}))
-	defer ts.Close()
+	var sawAuth bool
+	var gotURL, gotBody string
+	client := &http.Client{Transport: probeRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		if req.Header.Get("Authorization") != "" {
+			sawAuth = true
+		}
+		b, _ := io.ReadAll(req.Body)
+		gotBody = string(b)
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+	})}
 
-	status, detail := probeFirecrawl(testCtx(t), ts.Client(), config.FirecrawlSearchURL(config.DefaultFirecrawlURL), "")
-	if status != StatusNoKey {
-		t.Fatalf("status = %q, want no_key", status)
+	status, detail := probeFirecrawl(testCtx(t), client, config.FirecrawlSearchURL(config.DefaultFirecrawlURL), "")
+	if status != StatusOK {
+		t.Fatalf("status = %q (detail %q), want ok", status, detail)
 	}
-	if !strings.Contains(detail, "firecrawl_api_key") {
-		t.Errorf("detail %q should carry the config hint", detail)
+	if sawAuth {
+		t.Fatal("hosted keyless probe must omit Authorization")
+	}
+	if gotURL != config.FirecrawlSearchURL(config.DefaultFirecrawlURL) {
+		t.Errorf("url = %q, want hosted /v2/search", gotURL)
+	}
+	if !strings.Contains(gotBody, `"integration":"_ketch"`) {
+		t.Errorf("probe body %q must send integration _ketch like Search", gotBody)
+	}
+}
+
+func TestProbeFirecrawlHostedStatuses(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		code int
+		want Status
+	}{
+		{"keyless ok", "", http.StatusOK, StatusOK},
+		{"keyless rate limited", "", http.StatusTooManyRequests, StatusOK},
+		{"keyless credits", "", http.StatusPaymentRequired, StatusMisconfigured},
+		{"keyless unauthorized", "", http.StatusUnauthorized, StatusMisconfigured},
+		{"keyless forbidden", "", http.StatusForbidden, StatusOK},
+		{"keyed rate limited", "k", http.StatusTooManyRequests, StatusOK},
+		{"keyed rejected", "k", http.StatusUnauthorized, StatusMisconfigured},
+		{"keyed forbidden", "k", http.StatusForbidden, StatusMisconfigured},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{Transport: probeRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: tc.code, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+			})}
+			status, _ := probeFirecrawl(testCtx(t), client, config.FirecrawlSearchURL(config.DefaultFirecrawlURL), tc.key)
+			if status != tc.want {
+				t.Fatalf("status = %q, want %q", status, tc.want)
+			}
+		})
 	}
 }
 
@@ -728,6 +769,9 @@ func TestBuildSpecsRequiredGating(t *testing.T) {
 	}
 	if s := findSpec(t, specs, "search", "keenable"); s.required {
 		t.Error("keenable without a key and not default must be informational")
+	}
+	if s := findSpec(t, specs, "search", "firecrawl"); s.required {
+		t.Error("firecrawl without a key and not default must be informational")
 	}
 	if s := findSpec(t, specs, "search", "parallel"); s.required {
 		t.Error("parallel not default must be informational")

--- a/doctor/testdata/providers.json
+++ b/doctor/testdata/providers.json
@@ -27,8 +27,7 @@
   {
     "surface": "search",
     "backend": "firecrawl",
-    "status": "no_key",
-    "detail": "API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key \u003ckey\u003e)",
+    "status": "ok",
     "latency_ms": 0
   },
   {

--- a/mcp/search_test.go
+++ b/mcp/search_test.go
@@ -47,9 +47,9 @@ func TestRunSearchMultiValidation(t *testing.T) {
 		},
 		{
 			name:       "named but unconfigured backend",
-			in:         SearchInput{Query: "q", Multi: []string{"firecrawl"}},
+			in:         SearchInput{Query: "q", Multi: []string{"tavily"}},
 			wantPrefix: "[precondition]",
-			wantSubstr: "firecrawl",
+			wantSubstr: "tavily",
 		},
 		{
 			name:       "random and backend mutually exclusive",
@@ -77,9 +77,9 @@ func TestRunSearchMultiValidation(t *testing.T) {
 		},
 		{
 			name:       "random named but unconfigured backend",
-			in:         SearchInput{Query: "q", Random: []string{"firecrawl"}},
+			in:         SearchInput{Query: "q", Random: []string{"tavily"}},
 			wantPrefix: "[precondition]",
-			wantSubstr: "firecrawl",
+			wantSubstr: "tavily",
 		},
 	}
 	for _, tc := range cases {

--- a/search/config_test.go
+++ b/search/config_test.go
@@ -153,10 +153,21 @@ func TestNewFromConfigSerpBaseRequiresKey(t *testing.T) {
 }
 
 func TestNewFromConfigFirecrawlURL(t *testing.T) {
-	t.Run("cloud requires key", func(t *testing.T) {
+	t.Run("hosted allows empty key", func(t *testing.T) {
 		cfg := config.Defaults()
-		if _, err := NewFromConfig(&cfg, "firecrawl", ""); err == nil {
-			t.Fatal("expected missing-key error for hosted Firecrawl")
+		searcher, err := NewFromConfig(&cfg, "firecrawl", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		backend, ok := searcher.(*Firecrawl)
+		if !ok {
+			t.Fatalf("unexpected type %T", searcher)
+		}
+		if backend.keys.size() != 0 {
+			t.Fatalf("keys = %d, want 0", backend.keys.size())
+		}
+		if got := backend.endpoint; got != config.FirecrawlSearchURL(config.DefaultFirecrawlURL) {
+			t.Fatalf("endpoint = %q, want hosted /v2/search", got)
 		}
 	})
 

--- a/search/firecrawl.go
+++ b/search/firecrawl.go
@@ -22,6 +22,7 @@ type Firecrawl struct {
 }
 
 // NewFirecrawl creates a new Firecrawl search backend against the hosted API.
+// An empty apiKey uses the keyless hosted endpoint.
 func NewFirecrawl(apiKey string) *Firecrawl {
 	return newFirecrawlWithKeys([]string{apiKey}, config.DefaultFirecrawlURL)
 }
@@ -83,17 +84,8 @@ func (f *Firecrawl) Search(ctx context.Context, query string, limit int) ([]Resu
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("firecrawl: invalid API key (%s; set via: ketch config set firecrawl_api_key <key>)", f.keys.keyLabel(key))
-	}
-	if resp.StatusCode == http.StatusPaymentRequired {
-		return nil, fmt.Errorf("firecrawl: payment required (%s)", f.keys.keyLabel(key))
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("firecrawl: rate limited (%s)", f.keys.keyLabel(key))
-	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, firecrawlStatusError(resp)
+		return nil, firecrawlSearchStatusError(resp, key, f.keys.keyLabel(key))
 	}
 
 	var fr firecrawlResponse
@@ -139,6 +131,28 @@ func firecrawlRetryableStatus(status int) bool {
 	return status == http.StatusUnauthorized || status == http.StatusPaymentRequired || status == http.StatusTooManyRequests
 }
 
+func firecrawlSearchStatusError(resp *http.Response, key, keyLabel string) error {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		if key == "" {
+			return fmt.Errorf("firecrawl: unauthorized (set via: ketch config set firecrawl_api_key <key>)")
+		}
+		return fmt.Errorf("firecrawl: invalid API key (%s; set via: ketch config set firecrawl_api_key <key>)", keyLabel)
+	case http.StatusPaymentRequired:
+		if key == "" {
+			return fmt.Errorf("firecrawl: payment required (set a key: ketch config set firecrawl_api_key <key>)")
+		}
+		return fmt.Errorf("firecrawl: payment required (%s)", keyLabel)
+	case http.StatusTooManyRequests:
+		if key == "" {
+			return fmt.Errorf("firecrawl: rate limited (set a key to lift the cap: ketch config set firecrawl_api_key <key>)")
+		}
+		return fmt.Errorf("firecrawl: rate limited (%s)", keyLabel)
+	default:
+		return firecrawlStatusError(resp)
+	}
+}
+
 func firecrawlStatusError(resp *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if detail := strings.TrimSpace(string(body)); detail != "" {
@@ -147,17 +161,13 @@ func firecrawlStatusError(resp *http.Response) error {
 	return fmt.Errorf("firecrawl returned status %d", resp.StatusCode)
 }
 
-const firecrawlSearchBody = `{"query":"ketch","limit":1}`
+const firecrawlSearchBody = `{"query":"ketch","limit":1,"integration":"_ketch"}`
 const firecrawlLivenessBody = `{}`
 
 // ProbeFirecrawl checks the provider using a caller-supplied client and endpoint.
 func ProbeFirecrawl(ctx context.Context, client *http.Client, endpoint, apiKey string) (health.Status, string) {
 	key := strings.TrimSpace(apiKey)
 	hosted := strings.EqualFold(endpoint, config.FirecrawlSearchURL(config.DefaultFirecrawlURL))
-	if key == "" && hosted {
-		return health.StatusNoKey, "API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)"
-	}
-
 	body := firecrawlSearchBody
 	if !hosted {
 		body = firecrawlLivenessBody
@@ -180,15 +190,34 @@ func ProbeFirecrawl(ctx context.Context, client *http.Client, endpoint, apiKey s
 	if !hosted {
 		return firecrawlLivenessStatus(resp.StatusCode, key)
 	}
-	switch resp.StatusCode {
+	return firecrawlHostedStatus(resp.StatusCode, key)
+}
+
+func firecrawlHostedStatus(code int, key string) (health.Status, string) {
+	switch code {
 	case http.StatusOK:
 		return health.StatusOK, ""
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusPaymentRequired:
+	case http.StatusUnauthorized:
+		if key == "" {
+			return health.StatusMisconfigured, "request rejected (ketch config set firecrawl_api_key <key>)"
+		}
 		return health.StatusMisconfigured, "API key rejected (ketch config set firecrawl_api_key <key>)"
+	case http.StatusForbidden:
+		if key == "" {
+			// Hosted keyless 403 is Firecrawl's IP/bot gate, not a missing
+			// config key. Search from the same machine often still works.
+			return health.StatusOK, "reachable (keyless blocked; set a key to lift the cap)"
+		}
+		return health.StatusMisconfigured, "API key rejected (ketch config set firecrawl_api_key <key>)"
+	case http.StatusPaymentRequired:
+		return health.StatusMisconfigured, "credits exhausted (ketch config set firecrawl_api_key <key>)"
 	case http.StatusTooManyRequests:
+		if key == "" {
+			return health.StatusOK, "reachable (rate limited; set a key to lift the cap)"
+		}
 		return health.StatusOK, "reachable, key accepted (rate limited)"
 	default:
-		return health.StatusUnreachable, fmt.Sprintf("returned status %d", resp.StatusCode)
+		return health.StatusUnreachable, fmt.Sprintf("returned status %d", code)
 	}
 }
 
@@ -215,9 +244,8 @@ func firecrawlProvider() Provider {
 	return Provider{
 		Settings: []config.Setting{config.KeyPool("firecrawl_api_key", "firecrawl_api_keys", 6, 7, 4, 6), {Key: "firecrawl_url", ValidationOrder: 8, Default: "https://api.firecrawl.dev", FileOrder: 8, DiscoveryOrder: 9, EnvOrder: 5, Display: func(c *config.Config) string { return c.EffectiveFirecrawlURL() }}},
 		ID:       "firecrawl",
-		Setup:    "firecrawl: API key not set (get one free at https://firecrawl.dev then: ketch config set firecrawl_api_key <key>)",
 		Name:     "Firecrawl",
-		Usable:   func(c *config.Config) bool { return len(c.FirecrawlKeys()) > 0 || !c.IsDefaultFirecrawlURL() },
+		Usable:   func(*config.Config) bool { return true },
 		New: func(c *config.Config) (Searcher, error) {
 			return newFirecrawlWithKeys(c.FirecrawlKeys(), c.EffectiveFirecrawlURL()), nil
 		},

--- a/search/random_test.go
+++ b/search/random_test.go
@@ -119,7 +119,7 @@ func TestNewRandomFromConfigAllUsesEveryUsableBackend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"ddg", "searxng", "exa", "keenable", "parallel"}
+	want := []string{"ddg", "searxng", "exa", "firecrawl", "keenable", "parallel"}
 	if got := random.Names(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("resolved backends = %v, want %v", got, want)
 	}

--- a/search/search_feature_test.go
+++ b/search/search_feature_test.go
@@ -564,6 +564,27 @@ func TestFeatureFirecrawlRequestShape(t *testing.T) {
 	}
 }
 
+func TestFeatureFirecrawlHostedKeylessOmitsAuthorization(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want empty for keyless hosted", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"web":[{"url":"https://example.com","title":"Ex","description":"d"}]}}`)
+	}))
+	defer server.Close()
+
+	f := &Firecrawl{keys: newKeyPool(nil), client: &http.Client{Transport: &rewriteTransport{base: http.DefaultTransport, target: server.URL}}}
+	results, err := f.Search(context.Background(), "q", 1)
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+}
+
 func TestFeatureFirecrawlSelfHostedEndpoint(t *testing.T) {
 	t.Parallel()
 	var gotPath string

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -2,6 +2,11 @@
 
 This page mirrors the canonical [`CHANGELOG.md`](https://github.com/1broseidon/ketch/blob/main/CHANGELOG.md) in the repo root. Versions follow [Semantic Versioning](https://semver.org/) and match the published git tags.
 
+## Unreleased
+
+**Changed**
+- Hosted Firecrawl search is keyless by default. `ketch search -b firecrawl` no longer requires `firecrawl_api_key`; the same `POST /v2/search` call omits `Authorization` when no key is set, and `--multi=all` / `--random=all` include Firecrawl on a zero-config install. An optional key still lifts rate limits and credits, and still rotates on `401`/`429`/`402`. Self-hosted `firecrawl_url` is unchanged. `ketch doctor` probes the hosted endpoint instead of reporting `no_key`; the probe sends `integration: "_ketch"` like search, and a keyless hosted `403` is reported as reachable (same class as `429`) instead of `misconfigured`.
+
 ## v0.16.1 — 2026-09-07
 
 Version 0.16.0 was published on 2026-09-07 and withdrawn the same day; its Read the Docs backend and Context7 candidate resolution were not ready. The Go module proxy retains it, so this release carries a `retract v0.16.0` directive. 0.16.1 is 0.15.0 plus the fixes below and contains none of the 0.16.0 additions.

--- a/site/guide/configuration.md
+++ b/site/guide/configuration.md
@@ -91,7 +91,7 @@ ketch config set github_token ghp_...
 | `brave_api_keys` | — | Additional Brave keys (JSON array) — see [multiple keys](#multiple-api-keys-per-provider) |
 | `exa_api_key` | — | Optional Exa API key for authenticated hosted MCP usage |
 | `exa_api_keys` | — | Additional Exa keys (JSON array) |
-| `firecrawl_api_key` | — | [Firecrawl](https://docs.firecrawl.dev) API key (required for hosted `-b firecrawl`; optional for self-hosted) |
+| `firecrawl_api_key` | — | Optional [Firecrawl](https://docs.firecrawl.dev) API key; keyless by default, a key lifts the hosted rate limit / credits (also used if a self-hosted instance requires auth) |
 | `firecrawl_api_keys` | — | Additional Firecrawl keys (JSON array) |
 | `firecrawl_url` | `https://api.firecrawl.dev` | Firecrawl API base URL (self-hosted override; ketch appends `/v2/search`, and strips it if you paste the full endpoint) |
 | `keenable_api_key` | — | Optional Keenable API key; keyless by default, a key lifts the rate limit ([console](https://keenable.ai/console)) |

--- a/site/reference/backends.md
+++ b/site/reference/backends.md
@@ -65,13 +65,14 @@ ketch config set backend exa
 
 ## Firecrawl
 
-Web search via the [Firecrawl](https://firecrawl.dev) v2 [search API](https://docs.firecrawl.dev/api-reference/endpoint/search) — proper JSON API, no scraping. The hosted cloud API requires an API key; self-hosted instances often run without one.
+Web search via the [Firecrawl](https://firecrawl.dev) v2 [search API](https://docs.firecrawl.dev/api-reference/endpoint/search) — proper JSON API, no scraping. Hosted cloud is [keyless by default](https://www.firecrawl.dev/blog/firecrawl-keyless-launch) (rate-limited / credit-capped); an optional API key lifts the cap. Self-hosted instances often run without a key.
 
-**Setup (hosted):**
+**Setup:** None. Optional key to lift the rate limit:
 
-1. Get an API key at [firecrawl.dev](https://firecrawl.dev)
-2. Set it: `ketch config set firecrawl_api_key <your-key>`
-3. Make it the default: `ketch config set backend firecrawl`
+```sh
+ketch config set firecrawl_api_key <your-key>
+ketch config set backend firecrawl
+```
 
 **Setup (self-hosted):**
 

--- a/site/reference/commands.md
+++ b/site/reference/commands.md
@@ -36,7 +36,7 @@ naming the engines that returned it.
 
 - Bare `ketch search --multi "query"` (or `--multi=all`) uses every *usable*
   backend — the same key-presence rule ketch uses everywhere: `ddg`, `exa`,
-  `keenable`, and `parallel` always; `brave`, `firecrawl`, `tavily`, and `serpbase` only with a key; `searxng`
+  `firecrawl`, `keenable`, and `parallel` always; `brave`, `tavily`, and `serpbase` only with a key; `searxng`
   always (a dead instance just fails fast and is skipped); `degoog` only when
   `degoog_url` is set.
 - `ketch search --multi=brave,exa "query"` queries exactly those, in that order.

--- a/skills/ketch/references/surfaces.md
+++ b/skills/ketch/references/surfaces.md
@@ -28,11 +28,11 @@ The two transports expose the same options under different spellings. Both direc
 
 ## search
 
-- Backends: `brave` (default when unconfigured; free API key), `ddg` (zero setup; rate-limits readily under fan-out), `searxng` (self-hosted; needs a JSON-enabled instance — see the setup verb), `exa` (zero config), `firecrawl` (Firecrawl v2 search API; hosted needs `firecrawl_api_key`, self-hosted via `firecrawl_url`), `keenable` (keyless by default; optional `keenable_api_key` lifts the rate limit), `tavily` (keyed; extracted content in results; `tavily_api_key`), `parallel` (zero config; hosted Search MCP), `serpbase` (keyed Google results; `serpbase_api_key`).
+- Backends: `brave` (default when unconfigured; free API key), `ddg` (zero setup; rate-limits readily under fan-out), `searxng` (self-hosted; needs a JSON-enabled instance — see the setup verb), `exa` (zero config), `firecrawl` (Firecrawl v2 search API; keyless by default, optional `firecrawl_api_key` lifts the cap; self-hosted via `firecrawl_url`), `keenable` (keyless by default; optional `keenable_api_key` lifts the rate limit), `tavily` (keyed; extracted content in results; `tavily_api_key`), `parallel` (zero config; hosted Search MCP), `serpbase` (keyed Google results; `serpbase_api_key`).
 - The effective default backend is operator-configured: **omit `backend` to use it**; `ketch config` shows which it is.
 - `--scrape` / `scrape: true` fetches each result's full content — budget it exactly like a scrape (`max_chars`, `trim`).
 - `--minimal` (CLI): one result per line, tab-separated url/title/snippet (a 4th backends column is appended under `--multi` for plain search; `--scrape --minimal` keeps 3 columns).
-- `--multi` / `multi: [...]`: federated search — query several backends at once and rank-fuse with Reciprocal Rank Fusion (k=60), deduplicating by URL. Bare `--multi` / `["all"]` = every usable backend (key-presence rule); `--multi=brave,exa` / `["brave","exa"]` = a set (use the `=` form on the CLI). Each result gains a `backends` list (the engines that returned it — a consensus signal worth more than any single float). Backends that error or time out (10s each) are dropped: on the CLI they surface as `warn:` stderr lines + a `failed:` frontmatter key; on MCP as an additive `errors` map. The call fails ([upstream]/exit 4) only when every backend fails. Mutually exclusive with `backend`. Keys improve federation reliability (keyless `ddg`/`exa`/`keenable` rate-limit faster under fan-out).
+- `--multi` / `multi: [...]`: federated search — query several backends at once and rank-fuse with Reciprocal Rank Fusion (k=60), deduplicating by URL. Bare `--multi` / `["all"]` = every usable backend (key-presence rule); `--multi=brave,exa` / `["brave","exa"]` = a set (use the `=` form on the CLI). Each result gains a `backends` list (the engines that returned it — a consensus signal worth more than any single float). Backends that error or time out (10s each) are dropped: on the CLI they surface as `warn:` stderr lines + a `failed:` frontmatter key; on MCP as an additive `errors` map. The call fails ([upstream]/exit 4) only when every backend fails. Mutually exclusive with `backend`. Keys improve federation reliability (keyless `ddg`/`exa`/`firecrawl`/`keenable`/`parallel` rate-limit faster under fan-out).
 
 ## code
 
@@ -73,7 +73,7 @@ The two transports expose the same options under different spellings. Both direc
 
 | Surface | Keyless | Keyed | Set with |
 | --- | --- | --- | --- |
-| search | ddg, searxng (self-hosted), exa, keenable, parallel | brave, firecrawl, tavily, serpbase | `ketch config set brave_api_key <key>` / `firecrawl_api_key` / `tavily_api_key` / `serpbase_api_key` |
+| search | ddg, searxng (self-hosted), exa, firecrawl, keenable, parallel | brave, tavily, serpbase | `ketch config set brave_api_key <key>` / `tavily_api_key` / `serpbase_api_key` (optional `firecrawl_api_key` lifts Firecrawl's hosted cap) |
 | code | grepapp, sourcegraph | github | `gh auth login` / `$GITHUB_TOKEN` / `ketch config set github_token <tok>` |
 | docs | — | context7 (free key) | `ketch config set context7_api_key <key>` |
 

--- a/skills/ketch/references/verbs/setup.md
+++ b/skills/ketch/references/verbs/setup.md
@@ -64,7 +64,7 @@ On older ketch versions without `doctor`, configured-state detection is imperfec
 
    Right for: self-hosting preference, heavy volume, privacy.
 4. **exa — hosted alternative.** Works with zero config; `exa_api_key` exists for keyed use.
-5. **firecrawl — same provider as scrape/crawl.** Hosted needs a key: `ketch config set firecrawl_api_key <key>` (get one at firecrawl.dev), then `ketch config set backend firecrawl`. Self-hosted: `ketch config set firecrawl_url http://localhost:3002` (key optional if your instance skips auth).
+5. **firecrawl — same provider as scrape/crawl.** Keyless by default against the hosted API (rate-limited); optional `ketch config set firecrawl_api_key <key>` lifts the cap. Self-hosted: `ketch config set firecrawl_url http://localhost:3002` (key optional if your instance skips auth). Select with `ketch config set backend firecrawl`.
 6. **keenable — keyless by default.** Works with no key against the public endpoint (rate-limited); an optional `ketch config set keenable_api_key <key>` lifts the cap. Select with `ketch config set backend keenable`.
 7. **tavily — agent search with extracted content.** Needs a key: `ketch config set tavily_api_key <key>` (get one free at app.tavily.com), then `ketch config set backend tavily`. Results include richer extracted text in `content` (basic depth by default).
 8. **parallel — hosted Search MCP.** Works with zero config. Select with `ketch config set backend parallel`; results include excerpts in Ketch's standard description and content fields.


### PR DESCRIPTION
## Summary
- Hosted Firecrawl search no longer requires `firecrawl_api_key`. `ketch search -b firecrawl` POSTs `/v2/search` without `Authorization` when no key is set, matching [Firecrawl's keyless launch](https://www.firecrawl.dev/blog/firecrawl-keyless-launch).
- Firecrawl is always usable, so `--multi=all` and `--random=all` include it on a zero-config install (same rule as Keenable/Exa/Parallel). An optional key still lifts the hosted cap and still rotates on 401/429/402. Ketch's default backend stays `brave`.
- `ketch doctor` probes the hosted endpoint instead of reporting `no_key`. The probe sends `integration: "_ketch"` like search. A keyless hosted 403 (Firecrawl's IP/bot gate) is reported as reachable, not misconfigured — that 403 can fire while a real search from the same machine still works.

## Breaking changes / dependencies
None. No new dependencies. `ketch search -b firecrawl` with no key previously failed fast with a precondition error; it now performs a live (rate-limited) request instead — a behavior change, not a format/contract break. The `doctor` JSON schema (`surface`/`backend`/`status`/`latency_ms`/`detail`) is unchanged; only Firecrawl's own `status`/`detail` values shift to reflect that it's reachable without a key.

## Scope
This is a behavior change to an existing, already-registered provider (not a new provider), so [CONTRIBUTING.md](https://github.com/1broseidon/ketch/blob/main/CONTRIBUTING.md#proposing-a-provider)'s "open an issue first" applies to new providers only. Shared production code (`doctor.go`, `cmd/search.go`, `mcp/search.go`, `random.go`, `multi.go`) is untouched — all logic stays inside `search/firecrawl.go` and its own tests, per "shared production code must remain independent of provider names." README, site listings, and skill docs are updated in this same PR, and only Firecrawl's own fixture entries changed in `doctor/testdata/providers.json`.

## Test plan
- [x] `make build` (`CGO_ENABLED=0`)
- [x] `make test` (`go test ./...`)
- [x] `make lint` (`golangci-lint run`, v2 per `.golangci.yml`) — 0 issues
- [x] `gofmt -l .` — clean
- [x] Isolated empty config: `ketch search -b firecrawl "golang error wrapping" -l 2 --json` returns results with `firecrawl_api_key_set: false`
- [x] Installed v0.16.1 still reports Firecrawl `no_key` (no network); this branch probes live and returns `ok`
